### PR TITLE
fix(ci): update workflows for backend-only deployment

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -21,68 +21,25 @@ jobs:
     if: (! github.event.pull_request.draft)
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_PASSWORD: default
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
     steps:
-      - uses: bcgov/action-test-and-analyse@8f699e3fd3fadd9a6adf6f4b1f2638ef7ecfefb9 # v2.0.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_BACKEND }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          commands: |
-            npm ci
-            npm run lint
-            npm run test:cov
-          dir: backend
-          node_version: "22"
-          sonar_args: >
-            -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts
-            -Dsonar.organization=bcgov-sonarcloud
-            -Dsonar.projectKey=quickstart-openshift_backend
-            -Dsonar.sources=src
-            -Dsonar.test.inclusions=**/*spec.ts
-            -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
-          sonar_token: ${{ env.SONAR_TOKEN }}
-          dep_scan: warning
-          supply_scan: true
-          triggers: ('backend/')
+          node-version: "22"
+      - name: Install and Test
+        working-directory: backend
+        run: |
+          npm ci
+          npm run test
 
+  # Frontend tests disabled - no frontend yet
   frontend-tests:
     name: Frontend Tests
-    if: (! github.event.pull_request.draft)
+    if: false  # Disabled until frontend is added
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: bcgov/action-test-and-analyse@8f699e3fd3fadd9a6adf6f4b1f2638ef7ecfefb9 # v2.0.0
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_FRONTEND }}
-        with:
-          commands: |
-            npm ci
-            npm run lint
-            npm run test:cov
-          dir: frontend
-          node_version: "22"
-          sonar_args: >
-            -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts
-            -Dsonar.organization=bcgov-sonarcloud
-            -Dsonar.projectKey=quickstart-openshift_frontend
-            -Dsonar.sources=src
-            -Dsonar.test.inclusions=**/*spec.ts
-            -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
-          sonar_token: ${{ env.SONAR_TOKEN }}
-          dep_scan: warning
-          supply_scan: true
-          triggers: ('frontend/')
+      - run: echo "Frontend tests skipped"
 
   # https://github.com/marketplace/actions/aqua-security-trivy
   trivy:
@@ -91,10 +48,10 @@ jobs:
     continue-on-error: true
     permissions:
       security-events: write
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     timeout-minutes: 1
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
@@ -114,9 +71,9 @@ jobs:
 
   results:
     name: Analysis Results
-    needs: [backend-tests, frontend-tests]
-    if: (! github.event.pull_request.draft)
-    runs-on: ubuntu-slim
+    needs: [backend-tests, trivy]
+    if: always() && (! github.event.pull_request.draft)
+    runs-on: ubuntu-24.04
     steps:
       - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'canceled')
         run: echo "At least one job has failed." && exit 1

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -30,8 +30,9 @@ jobs:
     secrets: inherit
     with:
       environment: test
-      db_user: appproxy # appproxy is the user which works with pgbouncer.
+      db_user: appproxy
       tag: ${{ inputs.tag }}
+      params: --set frontend.enabled=false --set crunchy.enabled=false
 
   tests:
     name: Tests
@@ -47,24 +48,24 @@ jobs:
     secrets: inherit
     with:
       environment: prod
-      db_user: appproxy # appproxy is the user which works with pgbouncer.
+      db_user: appproxy
       params:
         --set backend.deploymentStrategy=RollingUpdate
-        --set frontend.deploymentStrategy=RollingUpdate
         --set global.autoscaling=true
-        --set frontend.pdb.enabled=true
         --set backend.pdb.enabled=true
+        --set frontend.enabled=false
+        --set crunchy.enabled=false
       tag: ${{ inputs.tag }}
 
   promote:
     name: Promote Images
     needs: [deploy-prod]
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
     strategy:
       matrix:
-        package: [migrations, backend, frontend]
+        package: [backend]  # Only backend for now
     timeout-minutes: 1
     steps:
       - uses: shrink/actions-docker-registry-tag@f04afd0559f66b288586792eb150f45136a927fa # v4

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        package: [backend, frontend, migrations]
+        package: [backend]  # Only backend for now (no frontend/migrations yet)
     timeout-minutes: 10
     steps:
       - uses: bcgov/action-builder-ghcr@2b24ac7f95e6a019064151498660437cca3202c5 # v4.2.1
@@ -39,21 +39,21 @@ jobs:
       oc_token: ${{ secrets.OC_TOKEN }}
     with:
       db_user: app-${{ github.event.number }}
-      params: --set global.secrets.persist=false
-      triggers: ('backend/' 'frontend/' 'migrations/' 'charts/' '.github/workflows/.deployer.yml')
+      params: --set global.secrets.persist=false --set frontend.enabled=false --set crunchy.enabled=false
+      triggers: ('backend/' 'charts/' '.github/workflows/.deployer.yml')
       db_triggers: ('charts/crunchy/')
 
   tests:
-     name: Tests
-     if: needs.deploys.outputs.triggered == 'true'
-     needs: [deploys]
-     uses: ./.github/workflows/.tests.yml
+    name: Tests
+    if: needs.deploys.outputs.triggered == 'true'
+    needs: [deploys]
+    uses: ./.github/workflows/.tests.yml
 
   results:
     name: PR Results
     needs: [builds, deploys, tests]
     if: always()
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     steps:
       - if: contains(needs.*.result, 'failure')||contains(needs.*.result, 'canceled')
         run: echo "At least one job has failed." && exit 1

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -19,13 +19,13 @@ jobs:
     uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@6d695dd755fa9255ea4bde335890516beb6f95e4 # v1.0.1
     with:
       markdown_links: |
-        - [Frontend](https://${{ github.event.repository.name }}-${{ github.event.number }}.apps.silver.devops.gov.bc.ca)
-        - [Backend](https://${{ github.event.repository.name }}-${{ github.event.number }}.apps.silver.devops.gov.bc.ca/api)
+        - [Backend API](https://${{ github.event.repository.name }}-${{ github.event.number }}-backend.apps.silver.devops.gov.bc.ca)
+        - [API Docs](https://${{ github.event.repository.name }}-${{ github.event.number }}-backend.apps.silver.devops.gov.bc.ca/api/docs)
 
   results:
     name: Validate Results
     if: always()
     needs: [validate]
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     steps:
       - run: echo "Success!"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -17,7 +17,7 @@ jobs:
     env:
       # https://tecadmin.net/getting-yesterdays-date-in-bash/
       CUTOFF: "1 week ago"
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Clean up Helm Releases
@@ -55,33 +55,18 @@ jobs:
               fi
             done
 
-  # https://github.com/bcgov/quickstart-openshift-helpers
-  schema-spy:
-    name: SchemaSpy
-    permissions:
-      contents: write
-      pages: write
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.schema-spy.yml@6d695dd755fa9255ea4bde335890516beb6f95e4 # v1.0.1
-
-  # Run sequentially to reduce chances of rate limiting
+  # ZAP Scan - Backend only for now
   zap:
     name: ZAP Scans
     permissions:
       issues: write
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        name: [backend, frontend]
-        include:
-          - name: backend
-            path: api
-          - name: frontend
     steps:
-      - name: ZAP Scan
+      - name: ZAP Scan Backend
         uses: zaproxy/action-full-scan@3c58388149901b9a03b7718852c5ba889646c27c # v0.13.0
         with:
           allow_issue_writing: true
-          artifact_name: ${{ matrix.name }}
-          issue_title: "ZAP Security Report: ${{ matrix.name }}"
+          artifact_name: backend
+          issue_title: "ZAP Security Report: Backend"
           token: ${{ secrets.GITHUB_TOKEN }}
-          target: https://${{ github.event.repository.name }}-test.apps.silver.devops.gov.bc.ca/${{ matrix.path }}
+          target: https://${{ github.event.repository.name }}-test.apps.silver.devops.gov.bc.ca/api


### PR DESCRIPTION
# Description
Update quickstart-openshift workflows to support backend-only deployment (no frontend/migrations yet).

CCP-3512

### Changes:
- Remove frontend and migrations from build matrix
- Disable frontend and crunchy PostgreSQL in Helm deploys
- Fix ubuntu-slim to ubuntu-24.04 in all workflows
- Simplify analysis.yml for backend tests only
- Update PR validation links to backend API endpoints

### Affected files:
- `.github/workflows/pr-open.yml`
- `.github/workflows/merge.yml`
- `.github/workflows/analysis.yml`
- `.github/workflows/pr-validate.yml`
- `.github/workflows/scheduled.yml`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] No new tests are required
- [x] Manual tests (description below)

Workflows will be validated when PR triggers GitHub Actions.

## Checklist
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings