### PR TITLE
CCP-3828: Implement remaining CHES API passthrough endpoints

### DIFF
--- a/backend/src/ches/ches-api.client.ts
+++ b/backend/src/ches/ches-api.client.ts
@@ -9,11 +9,22 @@ import { ConfigService } from '@nestjs/config';
 import { ChesOAuthService } from './ches-oauth.service';
 import { ChesMessageObject } from './v1/core/schemas/ches-message-object';
 import { ChesTransactionResponse } from './v1/core/schemas/ches-transaction-response';
+import { ChesMergeRequest } from './v1/core/schemas/ches-merge-request';
+import { ChesStatusObject } from './v1/core/schemas/ches-status-object';
+
+export { ChesMergeRequest, ChesStatusObject };
 
 interface ChesErrorResponse {
   detail?: string;
   message?: string;
   errors?: Array<{ message: string }>;
+}
+
+export interface ChesStatusQuery {
+  msgId?: string;
+  status?: string;
+  tag?: string;
+  txId?: string;
 }
 
 @Injectable()
@@ -109,8 +120,86 @@ export class ChesApiClient {
     return (await response.json()) as T;
   }
 
+  private buildQuery(params: ChesStatusQuery): string {
+    const qs = new URLSearchParams();
+    for (const [key, val] of Object.entries(params) as [
+      string,
+      string | undefined,
+    ][]) {
+      if (val !== undefined) qs.append(key, val);
+    }
+    const s = qs.toString();
+    return s ? `?${s}` : '';
+  }
+
   async sendEmail(body: ChesMessageObject): Promise<ChesTransactionResponse> {
     const token = await this.chesOAuthService.getValidToken();
     return this.request<ChesTransactionResponse>('POST', '/email', token, body);
+  }
+
+  async sendEmailMerge(
+    body: ChesMergeRequest,
+  ): Promise<ChesTransactionResponse[]> {
+    const token = await this.chesOAuthService.getValidToken();
+    return this.request<ChesTransactionResponse[]>(
+      'POST',
+      '/emailMerge',
+      token,
+      body,
+    );
+  }
+
+  async previewEmailMerge(
+    body: ChesMergeRequest,
+  ): Promise<ChesMessageObject[]> {
+    const token = await this.chesOAuthService.getValidToken();
+    return this.request<ChesMessageObject[]>(
+      'POST',
+      '/emailMerge/preview',
+      token,
+      body,
+    );
+  }
+
+  async getStatusQuery(query: ChesStatusQuery): Promise<ChesStatusObject[]> {
+    const token = await this.chesOAuthService.getValidToken();
+    return this.request<ChesStatusObject[]>(
+      'GET',
+      `/status${this.buildQuery(query)}`,
+      token,
+    );
+  }
+
+  async getStatusMessage(msgId: string): Promise<ChesStatusObject> {
+    const token = await this.chesOAuthService.getValidToken();
+    return this.request<ChesStatusObject>('GET', `/status/${msgId}`, token);
+  }
+
+  async promoteQuery(query: ChesStatusQuery): Promise<void> {
+    const token = await this.chesOAuthService.getValidToken();
+    return this.request<void>(
+      'POST',
+      `/promote${this.buildQuery(query)}`,
+      token,
+    );
+  }
+
+  async promoteMessage(msgId: string): Promise<void> {
+    const token = await this.chesOAuthService.getValidToken();
+    return this.request<void>('POST', `/promote/${msgId}`, token);
+  }
+
+  async cancelQuery(query: ChesStatusQuery): Promise<void> {
+    const token = await this.chesOAuthService.getValidToken();
+    return this.request<void>(
+      'DELETE',
+      `/cancel${this.buildQuery(query)}`,
+      token,
+    );
+  }
+
+  async cancelMessage(msgId: string): Promise<void> {
+    const token = await this.chesOAuthService.getValidToken();
+    return this.request<void>('DELETE', `/cancel/${msgId}`, token);
   }
 }

--- a/backend/src/ches/v1/core/ches.controller.ts
+++ b/backend/src/ches/v1/core/ches.controller.ts
@@ -7,6 +7,8 @@ import {
   Body,
   HttpCode,
   HttpStatus,
+  Param,
+  Query,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -17,11 +19,13 @@ import {
   ApiParam,
   ApiBody,
 } from '@nestjs/swagger';
-import { NotImplementedException } from '@nestjs/common';
 import { ApiKeyGuard } from '../../../common/guards';
 import { ChesApiClient } from '../../ches-api.client';
+import type { ChesStatusQuery } from '../../ches-api.client';
 import { ChesMessageObject } from './schemas/ches-message-object';
 import { ChesTransactionResponse } from './schemas/ches-transaction-response';
+import { ChesMergeRequest } from './schemas/ches-merge-request';
+import { ChesStatusObject } from './schemas/ches-status-object';
 
 @ApiTags('CHES')
 @ApiSecurity('api-key')
@@ -52,27 +56,40 @@ export class ChesController {
   }
 
   @Post('emailMerge')
-  @ApiOperation({ summary: 'Template mail merge and email sending (TODO)' })
-  @ApiResponse({ status: 501, description: 'Not implemented' })
-  postMerge(): never {
-    throw new NotImplementedException(
-      'TODO: Implement CHES email merge - POST /ches/emailMerge',
-    );
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Template mail merge and email sending' })
+  @ApiBody({ type: ChesMergeRequest, description: 'Merge request details' })
+  @ApiResponse({
+    status: 201,
+    description: 'Merge emails queued successfully',
+    type: [ChesTransactionResponse],
+  })
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async postMerge(
+    @Body() body: ChesMergeRequest,
+  ): Promise<ChesTransactionResponse[]> {
+    return this.chesApiClient.sendEmailMerge(body);
   }
 
   @Post('emailMerge/preview')
-  @ApiOperation({
-    summary: 'Template mail merge validation and preview (TODO)',
+  @ApiOperation({ summary: 'Template mail merge validation and preview' })
+  @ApiBody({ type: ChesMergeRequest, description: 'Merge request details' })
+  @ApiResponse({
+    status: 200,
+    description: 'Preview of merged messages',
+    type: [ChesMessageObject],
   })
-  @ApiResponse({ status: 501, description: 'Not implemented' })
-  postPreview(): never {
-    throw new NotImplementedException(
-      'TODO: Implement CHES email merge preview - POST /ches/emailMerge/preview',
-    );
+  @ApiResponse({ status: 400, description: 'Bad request' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async postPreview(
+    @Body() body: ChesMergeRequest,
+  ): Promise<ChesMessageObject[]> {
+    return this.chesApiClient.previewEmailMerge(body);
   }
 
   @Get('status')
-  @ApiOperation({ summary: 'Query CHES message status (TODO)' })
+  @ApiOperation({ summary: 'Query CHES message status' })
   @ApiQuery({ name: 'msgId', required: false })
   @ApiQuery({
     name: 'status',
@@ -81,57 +98,84 @@ export class ChesController {
   })
   @ApiQuery({ name: 'tag', required: false })
   @ApiQuery({ name: 'txId', required: false })
-  @ApiResponse({ status: 501, description: 'Not implemented' })
-  getStatusQuery(): never {
-    throw new NotImplementedException(
-      'TODO: Implement CHES status query - GET /ches/status',
-    );
+  @ApiResponse({
+    status: 200,
+    description: 'List of message statuses',
+    type: [ChesStatusObject],
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getStatusQuery(
+    @Query() query: ChesStatusQuery,
+  ): Promise<ChesStatusObject[]> {
+    return this.chesApiClient.getStatusQuery(query);
   }
 
   @Get('status/:msgId')
-  @ApiOperation({ summary: 'Get CHES message status (TODO)' })
-  @ApiParam({ name: 'msgId' })
-  @ApiResponse({ status: 501, description: 'Not implemented' })
-  getStatusMessage(): never {
-    throw new NotImplementedException(
-      'TODO: Implement CHES message status - GET /ches/status/:msgId',
-    );
+  @ApiOperation({ summary: 'Get CHES message status' })
+  @ApiParam({ name: 'msgId', description: 'Message UUID' })
+  @ApiResponse({ status: 200, description: 'Message status', type: ChesStatusObject })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Message not found' })
+  async getStatusMessage(
+    @Param('msgId') msgId: string,
+  ): Promise<ChesStatusObject> {
+    return this.chesApiClient.getStatusMessage(msgId);
   }
 
   @Post('promote')
-  @ApiOperation({ summary: 'Promote CHES messages (TODO)' })
-  @ApiResponse({ status: 501, description: 'Not implemented' })
-  postPromoteQuery(): never {
-    throw new NotImplementedException(
-      'TODO: Implement CHES promote - POST /ches/promote',
-    );
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({ summary: 'Promote CHES messages' })
+  @ApiQuery({ name: 'msgId', required: false })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ['accepted', 'cancelled', 'completed', 'failed', 'pending'],
+  })
+  @ApiQuery({ name: 'tag', required: false })
+  @ApiQuery({ name: 'txId', required: false })
+  @ApiResponse({ status: 202, description: 'Messages promoted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async postPromoteQuery(@Query() query: ChesStatusQuery): Promise<void> {
+    return this.chesApiClient.promoteQuery(query);
   }
 
   @Post('promote/:msgId')
-  @ApiOperation({ summary: 'Promote a single CHES message (TODO)' })
-  @ApiResponse({ status: 501, description: 'Not implemented' })
-  postPromoteMessage(): never {
-    throw new NotImplementedException(
-      'TODO: Implement CHES promote message - POST /ches/promote/:msgId',
-    );
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({ summary: 'Promote a single CHES message' })
+  @ApiParam({ name: 'msgId', description: 'Message UUID' })
+  @ApiResponse({ status: 202, description: 'Message promoted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Message not found' })
+  async postPromoteMessage(@Param('msgId') msgId: string): Promise<void> {
+    return this.chesApiClient.promoteMessage(msgId);
   }
 
   @Delete('cancel')
-  @ApiOperation({ summary: 'Cancel CHES messages (TODO)' })
-  @ApiResponse({ status: 501, description: 'Not implemented' })
-  deleteCancelQuery(): never {
-    throw new NotImplementedException(
-      'TODO: Implement CHES cancel - DELETE /ches/cancel',
-    );
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({ summary: 'Cancel CHES messages' })
+  @ApiQuery({ name: 'msgId', required: false })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: ['accepted', 'cancelled', 'completed', 'failed', 'pending'],
+  })
+  @ApiQuery({ name: 'tag', required: false })
+  @ApiQuery({ name: 'txId', required: false })
+  @ApiResponse({ status: 202, description: 'Messages cancelled' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async deleteCancelQuery(@Query() query: ChesStatusQuery): Promise<void> {
+    return this.chesApiClient.cancelQuery(query);
   }
 
   @Delete('cancel/:msgId')
-  @ApiOperation({ summary: 'Cancel a single CHES message (TODO)' })
-  @ApiResponse({ status: 501, description: 'Not implemented' })
-  deleteCancelMessage(): never {
-    throw new NotImplementedException(
-      'TODO: Implement CHES cancel message - DELETE /ches/cancel/:msgId',
-    );
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({ summary: 'Cancel a single CHES message' })
+  @ApiParam({ name: 'msgId', description: 'Message UUID' })
+  @ApiResponse({ status: 202, description: 'Message cancelled' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Message not found' })
+  async deleteCancelMessage(@Param('msgId') msgId: string): Promise<void> {
+    return this.chesApiClient.cancelMessage(msgId);
   }
 
   @Get('health')

--- a/backend/src/ches/v1/core/schemas/ches-merge-request.ts
+++ b/backend/src/ches/v1/core/schemas/ches-merge-request.ts
@@ -1,24 +1,24 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsArray, IsEmail, IsOptional, IsNumber, ValidateNested, IsObject } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ChesAttachmentObject } from './ches-message-object';
 
 export class ChesContextObject {
-  @ApiProperty() context: Record<string, unknown>;
-  @ApiProperty({ type: [String] }) to: string[];
-  @ApiPropertyOptional({ type: [String] }) bcc?: string[];
-  @ApiPropertyOptional({ type: [String] }) cc?: string[];
-  @ApiPropertyOptional() delayTS?: number;
-  @ApiPropertyOptional() tag?: string;
+  @ApiProperty() @IsObject() context: Record<string, unknown>;
+  @ApiProperty({ type: [String] }) @IsArray() @IsEmail({}, { each: true }) to: string[];
+  @ApiPropertyOptional({ type: [String] }) @IsOptional() @IsArray() bcc?: string[];
+  @ApiPropertyOptional({ type: [String] }) @IsOptional() @IsArray() cc?: string[];
+  @ApiPropertyOptional() @IsOptional() @IsNumber() delayTS?: number;
+  @ApiPropertyOptional() @IsOptional() @IsString() tag?: string;
 }
 
 export class ChesMergeRequest {
-  @ApiProperty({ enum: ['html', 'text'] }) bodyType: string;
-  @ApiProperty() body: string;
-  @ApiProperty({ type: [ChesContextObject] }) contexts: ChesContextObject[];
-  @ApiProperty() from: string;
-  @ApiProperty() subject: string;
-  @ApiPropertyOptional({ type: [ChesAttachmentObject] })
-  attachments?: ChesAttachmentObject[];
-  @ApiPropertyOptional({ enum: ['base64', 'binary', 'hex', 'utf-8'] })
-  encoding?: string;
-  @ApiPropertyOptional({ enum: ['normal', 'low', 'high'] }) priority?: string;
+  @ApiProperty({ enum: ['html', 'text'] }) @IsString() bodyType: string;
+  @ApiProperty() @IsString() body: string;
+  @ApiProperty({ type: [ChesContextObject] }) @IsArray() @ValidateNested({ each: true }) @Type(() => ChesContextObject) contexts: ChesContextObject[];
+  @ApiProperty() @IsString() from: string;
+  @ApiProperty() @IsString() subject: string;
+  @ApiPropertyOptional({ type: [ChesAttachmentObject] }) @IsOptional() @IsArray() attachments?: ChesAttachmentObject[];
+  @ApiPropertyOptional({ enum: ['base64', 'binary', 'hex', 'utf-8'] }) @IsOptional() @IsString() encoding?: string;
+  @ApiPropertyOptional({ enum: ['normal', 'low', 'high'] }) @IsOptional() @IsString() priority?: string;
 }


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

# Description
Completes the CHES API passthrough gateway by implementing all 
remaining TODO endpoints. All endpoints follow the same pure 
passthrough pattern as CCP-3322 — forward request to CHES API 
and return response directly. No business logic.

Fixes CCP-3828


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] Manual tests (description below)

Tested all endpoints locally against CHES dev environment:
- POST /emailMerge — sent 3 personalized emails in one call 
- POST /emailMerge/preview — verified template rendering 
- GET /status — queried by txId 
- GET /status/:msgId — checked individual email status 
- DELETE /cancel/:msgId — correct 409 for completed messages 
## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
