### PR TITLE
feat: ccp 3320 api gateway

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,6 +9,8 @@ POSTGRES_DB=notify
 # Application
 NODE_ENV=development
 PORT=3000
+# Behind API gateway / reverse proxy: set to 1 (one hop) or true so Express trusts X-Forwarded-For (required for express-rate-limit). See https://express-rate-limit.github.io/ERR_ERL_UNEXPECTED_X_FORWARDED_FOR/
+# TRUST_PROXY=1
 
 # Logging (trace, debug, info, warn, error, fatal). Default: debug in dev, info in prod.
 LOG_LEVEL=info
@@ -16,6 +18,7 @@ LOG_LEVEL=info
 # Rate limiting — global cap, then API (stricter) and public (lenient) per route
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX=100
+RATE_LIMIT_SERVICE_ROOT_MAX=2000
 RATE_LIMIT_API_WINDOW_MS=60000
 RATE_LIMIT_API_MAX=60
 RATE_LIMIT_PUBLIC_WINDOW_MS=60000

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -56,6 +56,21 @@ SMS_ADAPTER=twilio
 # GC Notify default template engine (jinja2, handlebars, ejs, mustache, nunjucks)
 GC_NOTIFY_DEFAULT_TEMPLATE_ENGINE=jinja2
 
+# Unified POST /notify: inline email (no stored notifyType/template). Subject, body, renderer, to in body.
+#NOTIFY_INLINE_EMAIL_ENABLED=true
+
+# Kong demo: gateway header auth + inject X-Delivery-Email-Adapter without bootstrap (remove DemoNotifyGatewayModule from AppModule when done)
+#DEMO_NOTIFY_GATEWAY_AUTH_ENABLED=true
+#DEMO_NOTIFY_GATEWAY_CLIENT_ID=my-kong-consumer-id
+#DEMO_NOTIFY_SENDER_EMAIL=demo-sender@example.com
+#DEMO_NOTIFY_EMAIL_ADAPTER=nodemailer
+#DEMO_NOTIFY_WORKSPACE_ID=default
+# Optional: comma-separated METHOD:path (default POST:/api/v1/notify)
+#DEMO_NOTIFY_AUTH_PATHS=POST:/api/v1/notify
+# Optional: override header name (else AUTH_GATEWAY_SERVICE_CLIENT_ID_HEADER)
+#DEMO_NOTIFY_GATEWAY_HEADER=x-consumer-custom-id
+#DEMO_NOTIFY_SMS_ADAPTER=twilio
+
 # GC Notify external (passthrough mode) - forward to real api.notification.canada.ca
 GC_NOTIFY_BASE_URL=https://api.notification.canada.ca
 GC_NOTIFY_EXTERNAL_ENABLED=false

--- a/backend/package.json
+++ b/backend/package.json
@@ -84,7 +84,9 @@
     "pino-pretty": "^13.1.2"
   },
   "jest": {
-    "setupFiles": ["<rootDir>/test/jest.setup.js"],
+    "setupFiles": [
+      "<rootDir>/test/jest.setup.js"
+    ],
     "moduleFileExtensions": [
       "js",
       "json",

--- a/backend/src/adapters/implementations/delivery/email/ches/ches-email.adapter.ts
+++ b/backend/src/adapters/implementations/delivery/email/ches/ches-email.adapter.ts
@@ -1,4 +1,11 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  BadGatewayException,
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
   IEmailTransport,
@@ -29,6 +36,12 @@ interface ChesEmailPayload {
 interface ChesEmailResponse {
   messages: Array<{ msgId: string; tag?: string; to: string[] }>;
   txId: string;
+}
+
+interface ChesErrorResponse {
+  detail?: string;
+  message?: string;
+  errors?: Array<{ message: string }>;
 }
 
 @Injectable()
@@ -81,11 +94,25 @@ export class ChesEmailTransport implements IEmailTransport {
 
     if (!response.ok) {
       const errText = await response.text();
-      this.logger.error(`CHES email failed: ${response.status} ${errText}`);
-      throw new Error(`CHES email failed: ${response.status} - ${errText}`);
+      this.throwForChesApiFailure(response.status, errText, 'email');
     }
 
-    const data = (await response.json()) as ChesEmailResponse;
+    let data: ChesEmailResponse;
+    try {
+      data = (await response.json()) as ChesEmailResponse;
+    } catch (caught: unknown) {
+      const errMeta =
+        caught instanceof Error
+          ? { name: caught.name, message: caught.message }
+          : { message: String(caught) };
+      this.logger.error(
+        errMeta,
+        'CHES email: success response was not valid JSON',
+      );
+      throw new BadGatewayException(
+        'CHES email returned a non-JSON response body',
+      );
+    }
     const messageId = data.messages?.[0]?.msgId ?? data.txId;
 
     return {
@@ -118,12 +145,25 @@ export class ChesEmailTransport implements IEmailTransport {
 
     if (!response.ok) {
       const errText = await response.text();
-      throw new Error(
-        `CHES token request failed: ${response.status} - ${errText}`,
-      );
+      this.throwForChesApiFailure(response.status, errText, 'token');
     }
 
-    const data = (await response.json()) as ChesTokenResponse;
+    let data: ChesTokenResponse;
+    try {
+      data = (await response.json()) as ChesTokenResponse;
+    } catch (caught: unknown) {
+      const errMeta =
+        caught instanceof Error
+          ? { name: caught.name, message: caught.message }
+          : { message: String(caught) };
+      this.logger.error(
+        errMeta,
+        'CHES token: success response was not valid JSON',
+      );
+      throw new BadGatewayException(
+        'CHES token endpoint returned a non-JSON response body',
+      );
+    }
     const expiresIn = data.expires_in ?? 300;
     this.tokenCache = {
       token: data.access_token,
@@ -131,6 +171,58 @@ export class ChesEmailTransport implements IEmailTransport {
     };
 
     return data.access_token;
+  }
+
+  /** Map CHES HTTP errors to Nest exceptions so callers see the upstream message (not a generic 500). */
+  private throwForChesApiFailure(
+    status: number,
+    errBody: string,
+    kind: 'email' | 'token',
+  ): never {
+    let errData: ChesErrorResponse | null = null;
+    try {
+      errData = JSON.parse(errBody) as ChesErrorResponse;
+    } catch {
+      this.logger.debug(
+        `CHES ${kind} non-JSON error body: ${errBody.slice(0, 200)}`,
+      );
+    }
+
+    const message =
+      errData?.detail ??
+      errData?.message ??
+      errData?.errors?.[0]?.message ??
+      errBody ??
+      String(status);
+
+    const label = kind === 'token' ? 'CHES token' : 'CHES email';
+    this.logger.error(
+      { status, kind, chesError: errBody.slice(0, 2000) },
+      `${label} request failed`,
+    );
+
+    if (status === 400) {
+      throw new BadRequestException(`${label}: ${message}`);
+    }
+    if (status === 401 || status === 403) {
+      throw new UnauthorizedException(`${label}: ${message}`);
+    }
+    if (status === 404) {
+      throw new NotFoundException(`${label}: ${message}`);
+    }
+    if (status === 422) {
+      throw new BadRequestException(`${label} validation: ${message}`);
+    }
+    if (status === 429) {
+      throw new BadRequestException(`${label} rate limit: ${message}`);
+    }
+    if (status >= 500) {
+      throw new BadGatewayException(
+        `${label}: upstream ${status} - ${message}`,
+      );
+    }
+
+    throw new BadGatewayException(`${label}: ${status} - ${message}`);
   }
 
   private mapAttachments(

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,4 +1,16 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { AppService } from './app.service';
 
+@ApiTags('API')
 @Controller()
-export class AppController {}
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'API base — service identity and probe paths' })
+  @ApiResponse({ status: 200, description: 'API metadata' })
+  getApiRoot() {
+    return this.appService.getApiRoot();
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -18,6 +18,9 @@ import { HealthModule } from './health/health.module';
 import { ContextModule } from './context/context.module';
 import { NotifyModule } from './notify/notify.module';
 import { RateLimitModule } from './common/rate-limit/rate-limit.module';
+import { DeliveryContextMiddleware } from './common/delivery-context/delivery-context.middleware';
+import { DemoInjectDeliveryHeadersMiddleware } from './demo-notify-gateway/demo-inject-delivery-headers.middleware';
+import { DemoNotifyGatewayModule } from './demo-notify-gateway/demo-notify-gateway.module';
 import configuration from './config/configuration';
 
 const config = configuration();
@@ -29,6 +32,7 @@ const config = configuration();
       envFilePath: ['.env', '.env.local'],
       load: [configuration],
     }),
+    DemoNotifyGatewayModule,
     AuthModule,
     AdaptersModule.forRoot({}),
     DeliveryContextModule,
@@ -50,4 +54,10 @@ const config = configuration();
   controllers: [AppController],
   providers: [AppService, ServiceRootRegistrar],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer
+      .apply(DemoInjectDeliveryHeadersMiddleware, DeliveryContextMiddleware)
+      .forRoutes('*path');
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { ServiceRootRegistrar } from './service-root.registrar';
 import { AdaptersModule } from './adapters/adapters.module';
 import { AuthModule } from './common/auth/auth.module';
 import { DeliveryContextModule } from './common/delivery-context/delivery-context.module';
@@ -47,6 +48,6 @@ const config = configuration();
     ChesModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, ServiceRootRegistrar],
 })
 export class AppModule {}

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -1,4 +1,24 @@
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
-export class AppService {}
+export class AppService {
+  /** Minimal response for `GET /` / `HEAD /` — stable across API versions (gateway probes). */
+  getServiceRoot() {
+    return {
+      status: 'ok',
+      service: 'bc-notify-api',
+      api: '/api/v1',
+    };
+  }
+
+  getApiRoot() {
+    return {
+      service: 'bc-notify-api',
+      apiVersion: 'v1',
+      documentation: '/api/docs',
+      health: '/api/v1/health',
+      live: '/api/v1/health/live',
+      ready: '/api/v1/health/ready',
+    };
+  }
+}

--- a/backend/src/common/auth/auth.module.ts
+++ b/backend/src/common/auth/auth.module.ts
@@ -13,10 +13,12 @@ import {
   SERVICE_CLIENT_REGISTRY,
   WORKSPACE_REGISTRY,
 } from './tokens';
+import { DemoGatewayNotifyAuthStrategy } from '../../demo-notify-gateway/demo-gateway-notify-auth.strategy';
+import { DemoNotifyGatewayModule } from '../../demo-notify-gateway/demo-notify-gateway.module';
 
 @Global()
 @Module({
-  imports: [ConfigModule],
+  imports: [ConfigModule, DemoNotifyGatewayModule],
   providers: [
     AuthenticatedGuard,
     PrincipalResolver,
@@ -36,13 +38,19 @@ import {
     {
       provide: AUTH_STRATEGIES,
       useFactory: (
+        demoGatewayNotifyAuthStrategy: DemoGatewayNotifyAuthStrategy,
         gatewayServiceClientAuthStrategy: GatewayServiceClientAuthStrategy,
         gcNotifyApiKeyAuthStrategy: GcNotifyApiKeyAuthStrategy,
       ): AuthStrategy[] => [
+        demoGatewayNotifyAuthStrategy,
         gatewayServiceClientAuthStrategy,
         gcNotifyApiKeyAuthStrategy,
       ],
-      inject: [GatewayServiceClientAuthStrategy, GcNotifyApiKeyAuthStrategy],
+      inject: [
+        DemoGatewayNotifyAuthStrategy,
+        GatewayServiceClientAuthStrategy,
+        GcNotifyApiKeyAuthStrategy,
+      ],
     },
   ],
   exports: [

--- a/backend/src/common/auth/principal-resolver.service.ts
+++ b/backend/src/common/auth/principal-resolver.service.ts
@@ -29,7 +29,7 @@ export class PrincipalResolver {
   }
 
   private getEnabledStrategies(): AuthStrategy[] {
-    const names = this.getConfiguredStrategies()
+    let names = this.getConfiguredStrategies()
       .map((item) => item.trim())
       .filter((item): item is AuthStrategyName => Boolean(item));
 
@@ -42,6 +42,13 @@ export class PrincipalResolver {
     const strategyMap = new Map(
       this.authStrategies.map((strategy) => [strategy.name, strategy]),
     );
+
+    if (
+      strategyMap.has('demo-gateway-notify') &&
+      !names.includes('demo-gateway-notify')
+    ) {
+      names = ['demo-gateway-notify', ...names];
+    }
 
     return names.map((name) => {
       const strategy = strategyMap.get(name);

--- a/backend/src/common/auth/types.ts
+++ b/backend/src/common/auth/types.ts
@@ -1,7 +1,10 @@
 import type { Request } from 'express';
 
 export type PrincipalType = 'service' | 'user';
-export type AuthSource = 'gateway-service-client' | 'gc-notify-api-key';
+export type AuthSource =
+  | 'gateway-service-client'
+  | 'gc-notify-api-key'
+  | 'demo-gateway-notify';
 export type AuthStrategyName = AuthSource;
 
 export interface RequestPrincipal {

--- a/backend/src/common/delivery-context/delivery-context.module.ts
+++ b/backend/src/common/delivery-context/delivery-context.module.ts
@@ -1,4 +1,4 @@
-import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { AdaptersModule } from '../../adapters/adapters.module';
 import { DeliveryContextMiddleware } from './delivery-context.middleware';
@@ -15,13 +15,10 @@ import { DeliveryAdapterResolver } from './delivery-adapter.resolver';
     DeliveryAdapterResolver,
   ],
   exports: [
+    DeliveryContextMiddleware,
     DeliveryContextService,
     DeliveryAdapterResolver,
     DeliveryContextStorage,
   ],
 })
-export class DeliveryContextModule implements NestModule {
-  configure(consumer: MiddlewareConsumer): void {
-    consumer.apply(DeliveryContextMiddleware).forRoutes('*path');
-  }
-}
+export class DeliveryContextModule {}

--- a/backend/src/common/rate-limit/rate-limit.module.ts
+++ b/backend/src/common/rate-limit/rate-limit.module.ts
@@ -1,7 +1,11 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { RequestMethod } from '@nestjs/common';
-import { createApiRateLimit, createPublicRateLimit } from './rate-limit';
+import {
+  createApiRateLimit,
+  createPublicRateLimit,
+  type RateLimitConfig,
+} from './rate-limit';
 import { HealthController } from '../../health/health.controller';
 import { NotifyController } from '../../notify/v1/core/notify.controller';
 import { ChesController } from '../../ches/v1/core/ches.controller';
@@ -16,14 +20,8 @@ export class RateLimitModule implements NestModule {
   constructor(private readonly configService: ConfigService) {}
 
   configure(consumer: MiddlewareConsumer): void {
-    const rateLimitConfig = this.configService.get<{
-      windowMs: number;
-      max: number;
-      apiWindowMs: number;
-      apiMax: number;
-      publicWindowMs: number;
-      publicMax: number;
-    }>('rateLimit');
+    const rateLimitConfig =
+      this.configService.get<RateLimitConfig>('rateLimit') ?? {};
 
     const publicRateLimit = createPublicRateLimit(rateLimitConfig);
     const apiRateLimit = createApiRateLimit(rateLimitConfig);

--- a/backend/src/common/rate-limit/rate-limit.ts
+++ b/backend/src/common/rate-limit/rate-limit.ts
@@ -9,6 +9,8 @@ const defaults: Partial<Options> = {
 export interface RateLimitConfig {
   windowMs: number;
   max: number;
+  /** Higher ceiling for `GET`/`HEAD /` (gateway probes) in the same window as `max`. */
+  serviceRootMax: number;
   apiWindowMs: number;
   apiMax: number;
   publicWindowMs: number;
@@ -18,18 +20,23 @@ export interface RateLimitConfig {
 const defaultConfig: RateLimitConfig = {
   windowMs: 60_000,
   max: 100,
+  serviceRootMax: 2000,
   apiWindowMs: 60_000,
   apiMax: 60,
   publicWindowMs: 60_000,
   publicMax: 200,
 };
 
+function isServiceRootProbe(req: { path: string; method: string }): boolean {
+  return req.path === '/' && (req.method === 'GET' || req.method === 'HEAD');
+}
+
 export function createGlobalRateLimit(config: Partial<RateLimitConfig> = {}) {
   const c = { ...defaultConfig, ...config };
   return rateLimit({
     ...defaults,
     windowMs: c.windowMs,
-    max: c.max,
+    max: (req) => (isServiceRootProbe(req) ? c.serviceRootMax : c.max),
   });
 }
 

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -1,12 +1,6 @@
 function parseTrustProxy(): number | undefined {
   const raw = process.env.TRUST_PROXY?.trim().toLowerCase();
-  if (
-    !raw ||
-    raw === 'false' ||
-    raw === '0' ||
-    raw === 'no' ||
-    raw === 'off'
-  ) {
+  if (!raw || raw === 'false' || raw === '0' || raw === 'no' || raw === 'off') {
     return undefined;
   }
   if (raw === 'true' || raw === 'yes' || raw === 'on' || raw === '1') {
@@ -127,6 +121,13 @@ export default () => {
         process.env.EMAIL_TRANSPORT ||
         'nodemailer',
       sms: process.env.SMS_ADAPTER || process.env.SMS_TRANSPORT || 'twilio',
+    },
+
+    // Unified /notify inline email (optional; no stored notify type or template)
+    notify: {
+      inlineEmailEnabled:
+        process.env.NOTIFY_INLINE_EMAIL_ENABLED === 'true' ||
+        process.env.NOTIFY_INLINE_EMAIL_ENABLED === '1',
     },
 
     // GC Notify template engine and external (passthrough mode)

--- a/backend/src/config/configuration.ts
+++ b/backend/src/config/configuration.ts
@@ -1,3 +1,24 @@
+function parseTrustProxy(): number | undefined {
+  const raw = process.env.TRUST_PROXY?.trim().toLowerCase();
+  if (
+    !raw ||
+    raw === 'false' ||
+    raw === '0' ||
+    raw === 'no' ||
+    raw === 'off'
+  ) {
+    return undefined;
+  }
+  if (raw === 'true' || raw === 'yes' || raw === 'on' || raw === '1') {
+    return 1;
+  }
+  const n = parseInt(raw, 10);
+  if (!Number.isNaN(n) && n >= 1) {
+    return n;
+  }
+  return undefined;
+}
+
 export default () => {
   const defaultEmailFrom =
     process.env.DEFAULT_EMAIL_FROM || 'noreply@localhost';
@@ -12,6 +33,8 @@ export default () => {
     // Application
     port: parseInt(process.env.PORT || '3000', 10),
     environment: process.env.NODE_ENV || 'development',
+    /** Express `trust proxy` hop count when `TRUST_PROXY` is set (required behind API gateway / LB for correct client IP + rate limiting). */
+    trustProxy: parseTrustProxy(),
 
     // Logging (trace, debug, info, warn, error, fatal)
     log: {
@@ -22,6 +45,10 @@ export default () => {
     rateLimit: {
       windowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || '60000', 10),
       max: parseInt(process.env.RATE_LIMIT_MAX || '100', 10),
+      serviceRootMax: parseInt(
+        process.env.RATE_LIMIT_SERVICE_ROOT_MAX || '2000',
+        10,
+      ),
       apiWindowMs: parseInt(
         process.env.RATE_LIMIT_API_WINDOW_MS || '60000',
         10,

--- a/backend/src/defaults/defaults.module.ts
+++ b/backend/src/defaults/defaults.module.ts
@@ -16,6 +16,13 @@ import { InMemoryDefaultsStore } from './stores/in-memory-defaults.store';
       useExisting: InMemoryDefaultsStore,
     },
   ],
-  exports: [DefaultsService],
+  exports: [
+    DefaultsService,
+    InMemoryDefaultsStore,
+    {
+      provide: DEFAULTS_STORE,
+      useExisting: InMemoryDefaultsStore,
+    },
+  ],
 })
 export class DefaultsModule {}

--- a/backend/src/demo-notify-gateway/README.md
+++ b/backend/src/demo-notify-gateway/README.md
@@ -1,0 +1,79 @@
+# Demo Notify Gateway
+
+Temporary module for **Kong-style demos**: authenticate a fixed gateway client header (e.g. `x-consumer-custom-id`) without `AUTH_BOOTSTRAP_PATH`, inject `X-Delivery-Email-Adapter` from env so callers do not send it, and seed an email identity + tenant defaults for the sender (`from`).
+
+**Security:** Only use behind an API gateway that **sets** the client id header and blocks clients from spoofing it. Treat `DEMO_NOTIFY_GATEWAY_CLIENT_ID` as a shared secret for allowlisted routes only.
+
+---
+
+## Configure
+
+### 1. Enable the module (already wired in this repo)
+
+The app imports `DemoNotifyGatewayModule` and chains middleware in `AppModule`; `AuthModule` registers the demo auth strategy when this module is present. If you are merging into another branch, ensure that wiring matches the current `AppModule` and `AuthModule`.
+
+### 2. Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DEMO_NOTIFY_GATEWAY_AUTH_ENABLED` | For demo | `true` or `1` to turn on demo auth + seed + header injection. **Unset or `false`:** demo strategy returns immediately (no principal), inject middleware does nothing; normal `gateway-service-client` / `gc-notify-api-key` and bootstrap apply. |
+| `DEMO_NOTIFY_GATEWAY_CLIENT_ID` | Yes* | Value that must match the gateway-injected client id header. |
+| `DEMO_NOTIFY_SENDER_EMAIL` | Yes* | Email used to create/find an identity; merged into defaults as `emailIdentityId` for `DEMO_NOTIFY_WORKSPACE_ID`. |
+| `DEMO_NOTIFY_EMAIL_ADAPTER` | Recommended | e.g. `nodemailer` or `ches` — injected as `X-Delivery-Email-Adapter` for allowlisted requests (caller header wins if already set). |
+| `DEMO_NOTIFY_WORKSPACE_ID` | No | Defaults to `default` (must exist in the in-memory workspace registry). |
+| `DEMO_NOTIFY_GATEWAY_HEADER` | No | Header name for the client id; falls back to `AUTH_GATEWAY_SERVICE_CLIENT_ID_HEADER`, then `x-consumer-custom-id`. |
+| `DEMO_NOTIFY_AUTH_PATHS` | No | Comma-separated rules: each `METHOD` + `:` + path (e.g. one entry `POST` + `:/api/v1/notify`). Default is notify-only. |
+| `DEMO_NOTIFY_SMS_ADAPTER` | No | Optional; injected as `X-Delivery-Sms-Adapter` when valid. |
+
+\*If auth is enabled but `DEMO_NOTIFY_GATEWAY_CLIENT_ID` is unset, the strategy and header middleware no-op (gateway/bootstrap behavior unchanged for that path).
+
+If `DEMO_NOTIFY_SENDER_EMAIL` is unset while auth is enabled, seeding is skipped (log warning).
+
+### 3. Inline `POST /notify` (separate product flag)
+
+To send without stored notify types or templates, set in app config:
+
+`NOTIFY_INLINE_EMAIL_ENABLED=true`
+
+See `NotifyService` / `.env.example`. Demo gateway auth and inline notify are independent flags; enable either or both as needed.
+
+### When all `DEMO_*` / demo flags are off
+
+- **`DEMO_NOTIFY_GATEWAY_AUTH_ENABLED`** unset, `false`, or not `true`/`1`: no header injection, no demo seed, `DemoGatewayNotifyAuthStrategy` always returns `null` on the first line.
+- Leftover **`DEMO_NOTIFY_EMAIL_ADAPTER`** / **`DEMO_NOTIFY_GATEWAY_CLIENT_ID`** etc. are **ignored** until auth is enabled (middleware and strategy both gate on `DEMO_NOTIFY_GATEWAY_AUTH_ENABLED`).
+- **`NOTIFY_INLINE_EMAIL_ENABLED`:** leave `false` or unset for classic template + `notifyType` `POST /notify` only.
+
+The demo module stays in the app graph; it is inert until `DEMO_NOTIFY_GATEWAY_AUTH_ENABLED` is on. Automated checks: `test/demo-notify-gateway/demo-disabled-auth-flow.spec.ts`.
+
+---
+
+## How it behaves
+
+1. **`DemoInjectDeliveryHeadersMiddleware`** runs **before** `DeliveryContextMiddleware`. For allowlisted method+path and matching gateway client id, it may set `x-delivery-email-adapter` / `x-delivery-sms-adapter` from env if not already present.
+2. **`DemoGatewayNotifyAuthStrategy`** runs (prepended by `PrincipalResolver` when registered) and returns a service principal for the same path + header match **before** `gateway-service-client` runs — avoiding “unknown service client” when bootstrap is empty.
+3. **`DemoNotifySeedService`** on startup creates or finds an identity for `DEMO_NOTIFY_SENDER_EMAIL` and merges `emailIdentityId` into defaults for the demo workspace.
+
+---
+
+## Remove this module
+
+1. **Delete** the folder `src/demo-notify-gateway/` (this README and all sources).
+2. **`AppModule`**
+   - Remove `DemoNotifyGatewayModule` from `imports`.
+   - Remove `implements NestModule` and `configure()` unless you still need it for another reason.
+   - Remove imports of `DemoInjectDeliveryHeadersMiddleware`, `DeliveryContextMiddleware` from `AppModule` if only used there.
+3. **`DeliveryContextModule`**
+   - Implement `NestModule` again and register middleware only for delivery context, e.g. `configure(consumer) { consumer.apply(DeliveryContextMiddleware).forRoutes('*path'); }`
+   - Optionally **stop exporting** `DeliveryContextMiddleware` if nothing else needs it (only required while `AppModule` applied it explicitly).
+4. **`AuthModule`**
+   - Remove `DemoNotifyGatewayModule` from `imports`.
+   - Remove imports of `DemoGatewayNotifyAuthStrategy` and `DemoNotifyGatewayModule`.
+   - Restore `AUTH_STRATEGIES` `useFactory` to only `gatewayServiceClientAuthStrategy` and `gcNotifyApiKeyAuthStrategy` with `inject` for those two only.
+5. **`PrincipalResolver`**
+   - Remove the block that prepends `demo-gateway-notify` when missing from configured strategy names.
+6. **`AuthSource` / types**
+   - Remove `'demo-gateway-notify'` from the `AuthSource` union in `src/common/auth/types.ts` if nothing else references it.
+7. **Env / docs**
+   - Remove `DEMO_*` entries from deployment config and `.env.example` if you added them there.
+
+After removal, rely on `AUTH_BOOTSTRAP_JSON` / bootstrap file + normal gateway auth, or `ApiKey-v1` auth, and set `X-Delivery-Email-Adapter` (or global `EMAIL_ADAPTER`) as before.

--- a/backend/src/demo-notify-gateway/demo-gateway-notify-auth.strategy.ts
+++ b/backend/src/demo-notify-gateway/demo-gateway-notify-auth.strategy.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import type { Request } from 'express';
+import type { AuthStrategy } from '../common/auth/interfaces/auth-strategy.interface';
+import type { RequestPrincipal } from '../common/auth/types';
+import {
+  getDemoNotifyGatewayClientHeaderName,
+  getDemoNotifyGatewayClientId,
+  getDemoNotifyWorkspaceId,
+  isDemoNotifyGatewayAuthEnabled,
+  requestMatchesDemoRequest,
+} from './demo-notify-settings';
+
+@Injectable()
+export class DemoGatewayNotifyAuthStrategy implements AuthStrategy {
+  readonly name = 'demo-gateway-notify' as const;
+
+  authenticate(request: Request): RequestPrincipal | null {
+    if (!isDemoNotifyGatewayAuthEnabled()) {
+      return null;
+    }
+
+    if (!requestMatchesDemoRequest(request)) {
+      return null;
+    }
+
+    const configuredId = getDemoNotifyGatewayClientId();
+    if (!configuredId) {
+      return null;
+    }
+
+    const headerName = getDemoNotifyGatewayClientHeaderName();
+    const presented = this.getHeader(request, headerName);
+    if (presented !== configuredId) {
+      return null;
+    }
+
+    const workspaceId = getDemoNotifyWorkspaceId();
+
+    return {
+      type: 'service',
+      subjectId: `demo-notify-gateway:${configuredId}`,
+      workspaceId,
+      workspaceKind: 'local',
+      gatewayClientId: configuredId,
+      authSource: 'demo-gateway-notify',
+    };
+  }
+
+  private getHeader(request: Request, name: string): string | undefined {
+    const key = name.toLowerCase();
+    const value = request.headers[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+    if (Array.isArray(value) && value[0]?.trim()) {
+      return value[0].trim();
+    }
+    return undefined;
+  }
+}

--- a/backend/src/demo-notify-gateway/demo-inject-delivery-headers.middleware.ts
+++ b/backend/src/demo-notify-gateway/demo-inject-delivery-headers.middleware.ts
@@ -1,0 +1,70 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import type { Request, Response, NextFunction } from 'express';
+import {
+  getDemoNotifyEmailAdapter,
+  getDemoNotifyGatewayClientHeaderName,
+  getDemoNotifyGatewayClientId,
+  getDemoNotifySmsAdapter,
+  isDemoNotifyGatewayAuthEnabled,
+  isValidDemoEmailAdapterKey,
+  isValidDemoSmsAdapterKey,
+  requestMatchesDemoRequest,
+} from './demo-notify-settings';
+
+function getHeader(req: Request, name: string): string | undefined {
+  const key = name.toLowerCase();
+  const value = req.headers[key];
+  if (typeof value === 'string' && value.trim()) {
+    return value.trim();
+  }
+  if (Array.isArray(value) && value[0]?.trim()) {
+    return value[0].trim();
+  }
+  return undefined;
+}
+
+@Injectable()
+export class DemoInjectDeliveryHeadersMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction): void {
+    if (!isDemoNotifyGatewayAuthEnabled()) {
+      next();
+      return;
+    }
+
+    const configuredId = getDemoNotifyGatewayClientId();
+    if (!configuredId) {
+      next();
+      return;
+    }
+
+    const headerName = getDemoNotifyGatewayClientHeaderName();
+    const presented = getHeader(req, headerName);
+    if (presented !== configuredId) {
+      next();
+      return;
+    }
+
+    if (!requestMatchesDemoRequest(req)) {
+      next();
+      return;
+    }
+
+    const emailAdapter = getDemoNotifyEmailAdapter();
+    if (emailAdapter && isValidDemoEmailAdapterKey(emailAdapter)) {
+      const existing = getHeader(req, 'x-delivery-email-adapter');
+      if (!existing) {
+        req.headers['x-delivery-email-adapter'] = emailAdapter;
+      }
+    }
+
+    const smsAdapter = getDemoNotifySmsAdapter();
+    if (smsAdapter && isValidDemoSmsAdapterKey(smsAdapter)) {
+      const existing = getHeader(req, 'x-delivery-sms-adapter');
+      if (!existing) {
+        req.headers['x-delivery-sms-adapter'] = smsAdapter;
+      }
+    }
+
+    next();
+  }
+}

--- a/backend/src/demo-notify-gateway/demo-notify-gateway.module.ts
+++ b/backend/src/demo-notify-gateway/demo-notify-gateway.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { DemoInjectDeliveryHeadersMiddleware } from './demo-inject-delivery-headers.middleware';
+import { DemoGatewayNotifyAuthStrategy } from './demo-gateway-notify-auth.strategy';
+import { DemoNotifySeedService } from './demo-notify-seed.service';
+import { IdentitiesModule } from '../identities/identities.module';
+import { DefaultsModule } from '../defaults/defaults.module';
+
+@Module({
+  imports: [IdentitiesModule, DefaultsModule],
+  providers: [
+    DemoInjectDeliveryHeadersMiddleware,
+    DemoGatewayNotifyAuthStrategy,
+    DemoNotifySeedService,
+  ],
+  exports: [DemoInjectDeliveryHeadersMiddleware, DemoGatewayNotifyAuthStrategy],
+})
+export class DemoNotifyGatewayModule {}

--- a/backend/src/demo-notify-gateway/demo-notify-seed.service.ts
+++ b/backend/src/demo-notify-gateway/demo-notify-seed.service.ts
@@ -1,0 +1,57 @@
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { DEFAULTS_STORE } from '../defaults/defaults.tokens';
+import type { DefaultsStore } from '../defaults/stores/defaults-store.interface';
+import { IdentitiesService } from '../identities/identities.service';
+import {
+  getDemoNotifySenderEmail,
+  getDemoNotifyWorkspaceId,
+  isDemoNotifyGatewayAuthEnabled,
+} from './demo-notify-settings';
+
+@Injectable()
+export class DemoNotifySeedService implements OnModuleInit {
+  private readonly logger = new Logger(DemoNotifySeedService.name);
+
+  constructor(
+    private readonly identitiesService: IdentitiesService,
+    @Inject(DEFAULTS_STORE) private readonly defaultsStore: DefaultsStore,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    if (!isDemoNotifyGatewayAuthEnabled()) {
+      return;
+    }
+
+    const email = getDemoNotifySenderEmail();
+    const workspaceId = getDemoNotifyWorkspaceId();
+    if (!email) {
+      this.logger.warn(
+        'DEMO_NOTIFY_GATEWAY_AUTH_ENABLED is on but DEMO_NOTIFY_SENDER_EMAIL is unset; skipping demo seed',
+      );
+      return;
+    }
+
+    const { identities } = await this.identitiesService.getIdentities('email');
+    let identityId = identities.find(
+      (i) => i.emailAddress?.toLowerCase() === email.toLowerCase(),
+    )?.id;
+
+    if (!identityId) {
+      const created = await this.identitiesService.createIdentity({
+        type: 'email',
+        emailAddress: email,
+        isDefault: true,
+      });
+      identityId = created.id;
+      this.logger.log(`Demo notify: created identity ${identityId}`);
+    }
+
+    this.defaultsStore.merge(workspaceId, {
+      emailIdentityId: identityId,
+      updatedAt: new Date().toISOString(),
+    });
+    this.logger.log(
+      `Demo notify: merged defaults for workspace ${workspaceId}`,
+    );
+  }
+}

--- a/backend/src/demo-notify-gateway/demo-notify-settings.ts
+++ b/backend/src/demo-notify-gateway/demo-notify-settings.ts
@@ -1,0 +1,117 @@
+/** Env-driven settings for Kong demo auth + delivery header injection. */
+
+export function isDemoNotifyGatewayAuthEnabled(): boolean {
+  const v = process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED?.trim().toLowerCase();
+  return v === 'true' || v === '1';
+}
+
+export function getDemoNotifyGatewayClientHeaderName(): string {
+  const fromDemo = process.env.DEMO_NOTIFY_GATEWAY_HEADER?.trim();
+  if (fromDemo) {
+    return fromDemo.toLowerCase();
+  }
+  const fromAuth = process.env.AUTH_GATEWAY_SERVICE_CLIENT_ID_HEADER?.trim();
+  if (fromAuth) {
+    return fromAuth.toLowerCase();
+  }
+  return 'x-consumer-custom-id';
+}
+
+export function getDemoNotifyGatewayClientId(): string | undefined {
+  const v = process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID?.trim();
+  return v || undefined;
+}
+
+export function getDemoNotifyWorkspaceId(): string {
+  return process.env.DEMO_NOTIFY_WORKSPACE_ID?.trim() || 'default';
+}
+
+export function getDemoNotifySenderEmail(): string | undefined {
+  const v = process.env.DEMO_NOTIFY_SENDER_EMAIL?.trim();
+  return v || undefined;
+}
+
+export function getDemoNotifyEmailAdapter(): string | undefined {
+  const v = process.env.DEMO_NOTIFY_EMAIL_ADAPTER?.trim().toLowerCase();
+  return v || undefined;
+}
+
+export function getDemoNotifySmsAdapter(): string | undefined {
+  const v = process.env.DEMO_NOTIFY_SMS_ADAPTER?.trim().toLowerCase();
+  return v || undefined;
+}
+
+const VALID_EMAIL_KEYS = new Set([
+  'nodemailer',
+  'ches',
+  'gc-notify:passthrough',
+  'ches:passthrough',
+]);
+const VALID_SMS_KEYS = new Set(['twilio', 'gc-notify:passthrough']);
+
+export function isValidDemoEmailAdapterKey(key: string): boolean {
+  return VALID_EMAIL_KEYS.has(key);
+}
+
+export function isValidDemoSmsAdapterKey(key: string): boolean {
+  return VALID_SMS_KEYS.has(key);
+}
+
+/** Entries like POST:/api/v1/notify */
+export function getDemoNotifyAuthPathRules(): Array<{
+  method: string;
+  path: string;
+}> {
+  const raw =
+    process.env.DEMO_NOTIFY_AUTH_PATHS?.trim() || 'POST:/api/v1/notify';
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const idx = entry.indexOf(':');
+      if (idx <= 0) {
+        return { method: '', path: '' };
+      }
+      const method = entry.slice(0, idx).trim().toUpperCase();
+      const path = entry.slice(idx + 1).trim();
+      return { method, path };
+    })
+    .filter((r) => r.method && r.path);
+}
+
+/** Path candidates for matching (Express may set path vs originalUrl differently under Nest). */
+export function getDemoRequestPathCandidates(req: {
+  path?: string;
+  originalUrl?: string;
+  url?: string;
+}): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (s: string | undefined) => {
+    if (!s) return;
+    const norm = s.split('?')[0] || s;
+    if (!norm || seen.has(norm)) return;
+    seen.add(norm);
+    out.push(norm);
+  };
+  push(req.path);
+  push(req.originalUrl);
+  push(req.url);
+  return out;
+}
+
+export function requestMatchesDemoRequest(req: {
+  method?: string;
+  path?: string;
+  originalUrl?: string;
+  url?: string;
+}): boolean {
+  const m = (req.method ?? 'GET').toUpperCase();
+  const candidates = getDemoRequestPathCandidates(req);
+  const rules = getDemoNotifyAuthPathRules();
+  return rules.some(
+    (r) =>
+      r.method === m && candidates.some((candidate) => candidate === r.path),
+  );
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,13 +8,22 @@ import { ConfigService } from '@nestjs/config';
 import { AppModule } from './app.module';
 import { httpLogger, log } from './common/logging';
 import { PinoLoggerService } from './common/logging/pino-logger.service';
-import { createRateLimiters } from './common/rate-limit/rate-limit';
+import {
+  createRateLimiters,
+  type RateLimitConfig,
+} from './common/rate-limit/rate-limit';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useLogger(new PinoLoggerService());
 
   const configService = app.get(ConfigService);
+  const expressApp = app.getHttpAdapter().getInstance() as Application;
+
+  const trustProxy = configService.get<number | undefined>('trustProxy');
+  if (trustProxy != null) {
+    expressApp.set('trust proxy', trustProxy);
+  }
 
   // Request ID and HTTP logging (must run early)
   app.use(
@@ -27,16 +36,9 @@ async function bootstrap() {
   app.use(httpLogger);
 
   // Global rate limit (route-specific limits applied via RateLimitModule)
-  const rateLimitConfig = configService.get<{
-    windowMs: number;
-    max: number;
-    apiWindowMs: number;
-    apiMax: number;
-    publicWindowMs: number;
-    publicMax: number;
-  }>('rateLimit');
-  const { globalRateLimit } = createRateLimiters(rateLimitConfig);
-  (app.getHttpAdapter().getInstance() as Application).use(globalRateLimit);
+  const rateLimitConfig = configService.get<RateLimitConfig>('rateLimit');
+  const { globalRateLimit } = createRateLimiters(rateLimitConfig ?? {});
+  expressApp.use(globalRateLimit);
 
   // Global validation pipe
   app.useGlobalPipes(
@@ -61,6 +63,7 @@ async function bootstrap() {
       { type: 'apiKey', name: 'Authorization', in: 'header' },
       'api-key',
     )
+    .addTag('API', 'Service metadata')
     .addTag('Health', 'Health check endpoints')
     .addTag('CHES', 'Common Hosted Email Service passthrough API')
     .addTag('Notify', 'Unified notification send and track')

--- a/backend/src/notify/notify.service.ts
+++ b/backend/src/notify/notify.service.ts
@@ -8,8 +8,10 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { v4 as uuidv4 } from 'uuid';
 import type {
+  IEmailTransport,
   ITemplateResolver,
   ITemplateRendererRegistry,
+  TemplateDefinition,
 } from '../adapters/interfaces';
 import {
   TEMPLATE_RESOLVER,
@@ -34,6 +36,8 @@ import type {
 @Injectable()
 export class NotifyService {
   private readonly logger = new Logger(NotifyService.name);
+  private static readonly INLINE_TEMPLATE_ID =
+    '00000000-0000-4000-8000-000000000001';
 
   constructor(
     private readonly configService: ConfigService,
@@ -57,6 +61,16 @@ export class NotifyService {
     ) {
       throw new BadRequestException(
         'Notify API supports only nodemailer and ches adapters. Use X-Delivery-Email-Adapter: nodemailer or ches.',
+      );
+    }
+
+    if (this.wantsInlineEmail(body)) {
+      return this.sendInlineEmail(body, emailAdapter);
+    }
+
+    if (!body.notifyType?.trim()) {
+      throw new BadRequestException(
+        'notifyType is required unless sending inline email (override.common.subject, body, renderer with NOTIFY_INLINE_EMAIL_ENABLED).',
       );
     }
 
@@ -118,13 +132,144 @@ export class NotifyService {
       'Notification',
     );
     const engine = template.engine ?? common.renderer ?? this.defaultEngine;
-    const renderer = this.rendererRegistry.getRenderer(engine);
+    let renderer;
+    try {
+      renderer = this.rendererRegistry.getRenderer(engine);
+    } catch (err) {
+      throw new BadRequestException(
+        err instanceof Error ? err.message : 'Unknown template renderer',
+      );
+    }
     const rendered = await renderer.renderEmail({
       template,
       personalisation: params,
       defaultSubject,
     });
     const subject = rendered.subject ?? defaultSubject;
+
+    const identity = emailIdentityId
+      ? await this.identitiesService.findById(emailIdentityId)
+      : this.identitiesService.getDefaultIdentity('email');
+    if (emailIdentityId && !identity) {
+      throw new NotFoundException(`Identity ${emailIdentityId} not found`);
+    }
+    const emailAdapterKey = this.deliveryContextService.getEmailAdapterKey();
+    const fromEmail =
+      identity?.email_address ??
+      this.configService.get<string>(`${emailAdapterKey}.from`) ??
+      this.configService.get<string>(
+        'defaults.email.from',
+        'noreply@localhost',
+      );
+
+    await emailAdapter.send({
+      to: to[0],
+      subject,
+      body: rendered.body,
+      from: fromEmail,
+      replyTo: identity?.email_address,
+      attachments: rendered.attachments,
+    });
+
+    const messages: MessageAssociation[] = [{ msgId, channel: 'email', to }];
+    return {
+      notifyId,
+      txId,
+      messages,
+    };
+  }
+
+  private wantsInlineEmail(body: NotifyRequest): boolean {
+    if (this.configService.get<boolean>('notify.inlineEmailEnabled') !== true) {
+      return false;
+    }
+    const common = body.override?.common;
+    if (!common) {
+      return false;
+    }
+    const to = common.to ?? [];
+    if (to.length !== 1) {
+      return false;
+    }
+    const sendAs = common.sendAs ?? 'email';
+    if (sendAs !== 'email') {
+      return false;
+    }
+    return (
+      this.nonEmptyTrimmed(common.subject) &&
+      this.nonEmptyTrimmed(common.body) &&
+      this.nonEmptyTrimmed(common.renderer)
+    );
+  }
+
+  private nonEmptyTrimmed(value: string | undefined): boolean {
+    return typeof value === 'string' && value.trim().length > 0;
+  }
+
+  private async sendInlineEmail(
+    body: NotifyRequest,
+    emailAdapter: IEmailTransport,
+  ): Promise<NotifyResponse> {
+    const override = body.override ?? {};
+    const common = override.common ?? {};
+    const emailOverride = override.email ?? {};
+    const to = common.to ?? [];
+    const defaults = this.defaultsService.getDefaults();
+    const emailIdentityId =
+      emailOverride.emailIdentityId ?? defaults.emailIdentityId;
+
+    if (to.length !== 1) {
+      throw new BadRequestException(
+        'Single email only: override.common.to must have exactly one recipient',
+      );
+    }
+
+    const subjectRaw = common.subject!.trim();
+    const bodyRaw = common.body!.trim();
+    const rendererName = common.renderer!.trim();
+
+    const syntheticTemplate: TemplateDefinition = {
+      id: NotifyService.INLINE_TEMPLATE_ID,
+      type: 'email',
+      name: 'inline-notify',
+      subject: subjectRaw,
+      body: bodyRaw,
+      active: true,
+      engine: rendererName,
+    };
+
+    const defaultSubject = this.configService.get<string>(
+      'defaults.templates.defaultSubject',
+      'Notification',
+    );
+
+    let renderer;
+    try {
+      renderer = this.rendererRegistry.getRenderer(rendererName);
+    } catch (err) {
+      throw new BadRequestException(
+        err instanceof Error ? err.message : 'Unknown template renderer',
+      );
+    }
+
+    const params = { ...(common.params ?? {}) };
+    const outputType =
+      common.bodyType === 'text' ? ('text' as const) : ('html' as const);
+
+    const rendered = await renderer.renderEmail(
+      {
+        template: syntheticTemplate,
+        personalisation: params,
+        defaultSubject,
+      },
+      { outputType },
+    );
+    const subject = rendered.subject ?? defaultSubject;
+
+    const notifyId = uuidv4();
+    const txId = uuidv4();
+    const msgId = uuidv4();
+    this.logger.log(`Notify inline send: ${notifyId} to ${to[0]}`);
 
     const identity = emailIdentityId
       ? await this.identitiesService.findById(emailIdentityId)

--- a/backend/src/notify/v1/core/notify.controller.ts
+++ b/backend/src/notify/v1/core/notify.controller.ts
@@ -30,7 +30,10 @@ export class NotifyController {
   @Post()
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
-    summary: 'Send a notification using stored defaults for notifyType',
+    summary:
+      'Send a notification (template mode or inline email when NOTIFY_INLINE_EMAIL_ENABLED)',
+    description:
+      'Template mode: pass notifyType and templateId (or notify type defaults). Inline mode (feature flag): omit notifyType; pass override.common.to, subject, body, renderer, optional params/bodyType; sender (from) from identity/defaults.',
   })
   @ApiHeader({
     name: 'X-Delivery-Email-Adapter',

--- a/backend/src/notify/v1/core/schemas/notify-request.ts
+++ b/backend/src/notify/v1/core/schemas/notify-request.ts
@@ -1,15 +1,17 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsString, IsOptional, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { OverrideOrAugment } from './override-or-augment';
 
 export class NotifyRequest {
-  @ApiProperty({
-    description: 'Identifier for a stored defaults profile (notifyType code)',
+  @ApiPropertyOptional({
+    description:
+      'Required for template mode (stored notify type). Omit when using inline email (NOTIFY_INLINE_EMAIL_ENABLED + subject, body, renderer in override.common).',
     example: 'single-email',
   })
+  @IsOptional()
   @IsString()
-  notifyType: string;
+  notifyType?: string;
 
   @ApiPropertyOptional()
   @IsOptional()

--- a/backend/src/service-root.registrar.ts
+++ b/backend/src/service-root.registrar.ts
@@ -1,0 +1,23 @@
+import type { Application } from 'express';
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { AppService } from './app.service';
+
+/** Registers `GET /` and `HEAD /` for gateway / LB probes (version-agnostic). */
+@Injectable()
+export class ServiceRootRegistrar implements OnModuleInit {
+  constructor(
+    private readonly appService: AppService,
+    private readonly adapterHost: HttpAdapterHost,
+  ) {}
+
+  onModuleInit() {
+    const expressApp: Application = this.adapterHost.httpAdapter.getInstance();
+    expressApp.get('/', (_req, res) => {
+      res.status(200).json(this.appService.getServiceRoot());
+    });
+    expressApp.head('/', (_req, res) => {
+      res.status(200).end();
+    });
+  }
+}

--- a/backend/test/app.controller.spec.ts
+++ b/backend/test/app.controller.spec.ts
@@ -1,18 +1,41 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from '../src/app.controller';
+import { AppService } from '../src/app.service';
 
 describe('AppController', () => {
   let appController: AppController;
+  let moduleRef: TestingModule;
 
   beforeEach(async () => {
-    const app: TestingModule = await Test.createTestingModule({
+    moduleRef = await Test.createTestingModule({
       controllers: [AppController],
+      providers: [AppService],
     }).compile();
 
-    appController = app.get<AppController>(AppController);
+    appController = moduleRef.get<AppController>(AppController);
   });
 
   it('should be defined', () => {
     expect(appController).toBeDefined();
+  });
+
+  it('getApiRoot returns service metadata and health paths', () => {
+    expect(appController.getApiRoot()).toEqual({
+      service: 'bc-notify-api',
+      apiVersion: 'v1',
+      documentation: '/api/docs',
+      health: '/api/v1/health',
+      live: '/api/v1/health/live',
+      ready: '/api/v1/health/ready',
+    });
+  });
+
+  it('getServiceRoot (via AppService) is gateway-stable', () => {
+    const appService = moduleRef.get(AppService);
+    expect(appService.getServiceRoot()).toEqual({
+      status: 'ok',
+      service: 'bc-notify-api',
+      api: '/api/v1',
+    });
   });
 });

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -13,12 +13,62 @@ describe('AppController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api/v1');
     await app.init();
   });
 
-  it('/health (GET)', () => {
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('/ (GET) returns gateway-stable service root', () => {
     return request(app.getHttpServer())
-      .get('/health')
+      .get('/')
+      .expect(200)
+      .expect(
+        (res: {
+          body: { status?: string; service?: string; api?: string };
+        }) => {
+          expect(res.body.status).toBe('ok');
+          expect(res.body.service).toBe('bc-notify-api');
+          expect(res.body.api).toBe('/api/v1');
+        },
+      );
+  });
+
+  it('/ (HEAD) returns 200 (no response body)', async () => {
+    const res = await request(app.getHttpServer()).head('/').expect(200);
+    expect(res.body).toEqual({});
+  });
+
+  it('/api/v1 (GET) returns API base metadata', () => {
+    return request(app.getHttpServer())
+      .get('/api/v1')
+      .expect(200)
+      .expect(
+        (res: {
+          body: {
+            service?: string;
+            apiVersion?: string;
+            documentation?: string;
+            health?: string;
+            live?: string;
+            ready?: string;
+          };
+        }) => {
+          expect(res.body.service).toBe('bc-notify-api');
+          expect(res.body.apiVersion).toBe('v1');
+          expect(res.body.documentation).toBe('/api/docs');
+          expect(res.body.health).toBe('/api/v1/health');
+          expect(res.body.live).toBe('/api/v1/health/live');
+          expect(res.body.ready).toBe('/api/v1/health/ready');
+        },
+      );
+  });
+
+  it('/api/v1/health (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/api/v1/health')
       .expect(200)
       .expect((res: { body: { status?: string; service?: string } }) => {
         expect(res.body.status).toBe('ok');

--- a/backend/test/common/auth/principal-resolver.service.spec.ts
+++ b/backend/test/common/auth/principal-resolver.service.spec.ts
@@ -121,6 +121,44 @@ describe('PrincipalResolver', () => {
     expect(gcNotifyAuthenticateMock).not.toHaveBeenCalled();
   });
 
+  it('prepends demo-gateway-notify when that strategy is registered', async () => {
+    const demoAuthenticateMock = jest.fn().mockReturnValue(null);
+    const demoStrategy: AuthStrategy = {
+      name: 'demo-gateway-notify',
+      authenticate: demoAuthenticateMock,
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PrincipalResolver,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              switch (key) {
+                case 'auth.strategies':
+                  return ['gateway-service-client', 'gc-notify-api-key'];
+                default:
+                  return undefined;
+              }
+            }),
+          },
+        },
+        {
+          provide: AUTH_STRATEGIES,
+          useValue: [demoStrategy, gatewayStrategy, gcNotifyApiKeyStrategy],
+        },
+      ],
+    }).compile();
+
+    const resolver = module.get(PrincipalResolver);
+    gatewayAuthenticateMock.mockReturnValue(null);
+    gcNotifyAuthenticateMock.mockReturnValue(null);
+
+    resolver.resolveOptional({ headers: {} } as never);
+
+    expect(demoAuthenticateMock).toHaveBeenCalled();
+  });
+
   it('fails fast when an unsupported strategy is configured', async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/backend/test/common/rate-limit/rate-limit.spec.ts
+++ b/backend/test/common/rate-limit/rate-limit.spec.ts
@@ -31,6 +31,24 @@ test('global rate limit: third GET returns 429 and JSON error body', async () =>
   expect(res.body).toEqual(rateLimitErrorBody);
 });
 
+test('global rate limit: GET / uses higher serviceRootMax', async () => {
+  const app = express();
+  app.use(
+    createGlobalRateLimit({
+      max: 2,
+      serviceRootMax: 4,
+      windowMs: 60_000,
+    }),
+  );
+  app.get('/', (_req, res) => res.json({ ok: true }));
+  const agent = request(app);
+  for (let i = 0; i < 4; i++) {
+    await agent.get('/').expect(200);
+  }
+  const res = await agent.get('/').expect(429);
+  expect(res.body).toEqual(rateLimitErrorBody);
+});
+
 test('API rate limit: second POST returns 429 and JSON error body', async () => {
   const agent = request(appWithApiMax(1));
   await agent.post('/api/x').expect(201);

--- a/backend/test/config/configuration.spec.ts
+++ b/backend/test/config/configuration.spec.ts
@@ -9,6 +9,7 @@ afterEach(() => {
 test('configuration: default rate limits and debug log level when env omits those vars', () => {
   delete process.env.RATE_LIMIT_WINDOW_MS;
   delete process.env.RATE_LIMIT_MAX;
+  delete process.env.RATE_LIMIT_SERVICE_ROOT_MAX;
   delete process.env.RATE_LIMIT_API_WINDOW_MS;
   delete process.env.RATE_LIMIT_API_MAX;
   delete process.env.RATE_LIMIT_PUBLIC_WINDOW_MS;
@@ -21,6 +22,7 @@ test('configuration: default rate limits and debug log level when env omits thos
   expect(config.rateLimit).toEqual({
     windowMs: 60_000,
     max: 100,
+    serviceRootMax: 2000,
     apiWindowMs: 60_000,
     apiMax: 60,
     publicWindowMs: 60_000,
@@ -43,9 +45,37 @@ test('configuration: log level matches LOG_LEVEL when set', () => {
   expect(configuration().log.level).toBe('warn');
 });
 
+test('configuration: trustProxy is undefined when TRUST_PROXY is unset or disabled', () => {
+  delete process.env.TRUST_PROXY;
+  expect(configuration().trustProxy).toBeUndefined();
+
+  process.env.TRUST_PROXY = 'false';
+  expect(configuration().trustProxy).toBeUndefined();
+
+  process.env.TRUST_PROXY = '0';
+  expect(configuration().trustProxy).toBeUndefined();
+});
+
+test('configuration: trustProxy is 1 when TRUST_PROXY enables trust (typical single gateway hop)', () => {
+  process.env.TRUST_PROXY = '1';
+  expect(configuration().trustProxy).toBe(1);
+
+  process.env.TRUST_PROXY = 'true';
+  expect(configuration().trustProxy).toBe(1);
+
+  process.env.TRUST_PROXY = 'yes';
+  expect(configuration().trustProxy).toBe(1);
+});
+
+test('configuration: trustProxy parses multi-hop proxy count', () => {
+  process.env.TRUST_PROXY = '2';
+  expect(configuration().trustProxy).toBe(2);
+});
+
 test('configuration: rate limit fields match parsed env values', () => {
   process.env.RATE_LIMIT_WINDOW_MS = '120000';
   process.env.RATE_LIMIT_MAX = '10';
+  process.env.RATE_LIMIT_SERVICE_ROOT_MAX = '5000';
   process.env.RATE_LIMIT_API_WINDOW_MS = '30000';
   process.env.RATE_LIMIT_API_MAX = '5';
   process.env.RATE_LIMIT_PUBLIC_WINDOW_MS = '90000';
@@ -54,6 +84,7 @@ test('configuration: rate limit fields match parsed env values', () => {
   expect(configuration().rateLimit).toEqual({
     windowMs: 120_000,
     max: 10,
+    serviceRootMax: 5000,
     apiWindowMs: 30_000,
     apiMax: 5,
     publicWindowMs: 90_000,

--- a/backend/test/config/configuration.spec.ts
+++ b/backend/test/config/configuration.spec.ts
@@ -72,6 +72,14 @@ test('configuration: trustProxy parses multi-hop proxy count', () => {
   expect(configuration().trustProxy).toBe(2);
 });
 
+test('configuration: notify.inlineEmailEnabled when NOTIFY_INLINE_EMAIL_ENABLED set', () => {
+  delete process.env.NOTIFY_INLINE_EMAIL_ENABLED;
+  expect(configuration().notify.inlineEmailEnabled).toBe(false);
+
+  process.env.NOTIFY_INLINE_EMAIL_ENABLED = 'true';
+  expect(configuration().notify.inlineEmailEnabled).toBe(true);
+});
+
 test('configuration: rate limit fields match parsed env values', () => {
   process.env.RATE_LIMIT_WINDOW_MS = '120000';
   process.env.RATE_LIMIT_MAX = '10';

--- a/backend/test/demo-notify-gateway/demo-disabled-auth-flow.spec.ts
+++ b/backend/test/demo-notify-gateway/demo-disabled-auth-flow.spec.ts
@@ -1,0 +1,126 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import type { Request, Response } from 'express';
+import type { AuthStrategy } from '../../src/common/auth/interfaces/auth-strategy.interface';
+import { PrincipalResolver } from '../../src/common/auth/principal-resolver.service';
+import { AUTH_STRATEGIES } from '../../src/common/auth/tokens';
+import { DemoInjectDeliveryHeadersMiddleware } from '../../src/demo-notify-gateway/demo-inject-delivery-headers.middleware';
+import { DemoGatewayNotifyAuthStrategy } from '../../src/demo-notify-gateway/demo-gateway-notify-auth.strategy';
+
+const envSnapshot = { ...process.env };
+
+describe('Demo notify disabled (DEMO_* off)', () => {
+  afterEach(() => {
+    process.env = { ...envSnapshot };
+  });
+
+  async function createResolverWithRealDemo(
+    gatewayAuthenticate: AuthStrategy['authenticate'],
+    gcAuthenticate: AuthStrategy['authenticate'],
+  ): Promise<PrincipalResolver> {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PrincipalResolver,
+        DemoGatewayNotifyAuthStrategy,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'auth.strategies') {
+                return ['gateway-service-client', 'gc-notify-api-key'];
+              }
+              return undefined;
+            }),
+          },
+        },
+        {
+          provide: AUTH_STRATEGIES,
+          useFactory: (demo: DemoGatewayNotifyAuthStrategy) => {
+            const gatewayStrategy: AuthStrategy = {
+              name: 'gateway-service-client',
+              authenticate: gatewayAuthenticate,
+            };
+            const gcStrategy: AuthStrategy = {
+              name: 'gc-notify-api-key',
+              authenticate: gcAuthenticate,
+            };
+            return [demo, gatewayStrategy, gcStrategy];
+          },
+          inject: [DemoGatewayNotifyAuthStrategy],
+        },
+      ],
+    }).compile();
+
+    return module.get(PrincipalResolver);
+  }
+
+  it('PrincipalResolver: real demo strategy returns null when env unset; gateway authenticates', async () => {
+    delete process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED;
+    delete process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID;
+
+    const gatewayMock = jest.fn().mockReturnValue({
+      type: 'service',
+      subjectId: 'svc-1',
+      workspaceId: 'workspace-1',
+      authSource: 'gateway-service-client',
+    });
+    const gcMock = jest.fn().mockReturnValue(null);
+
+    const resolver = await createResolverWithRealDemo(gatewayMock, gcMock);
+    const req = {
+      method: 'POST',
+      path: '/api/v1/notify',
+      headers: { 'x-consumer-custom-id': 'any' },
+    } as never;
+
+    const principal = resolver.resolveOptional(req);
+
+    expect(principal?.authSource).toBe('gateway-service-client');
+    expect(gatewayMock).toHaveBeenCalledWith(req);
+    expect(gcMock).not.toHaveBeenCalled();
+  });
+
+  it('PrincipalResolver: DEMO_NOTIFY_GATEWAY_AUTH_ENABLED=false falls through to gateway', async () => {
+    process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED = 'false';
+    process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID = 'would-match-if-enabled';
+
+    const gatewayMock = jest.fn().mockReturnValue({
+      type: 'service',
+      subjectId: 'svc-1',
+      workspaceId: 'default',
+      authSource: 'gateway-service-client',
+    });
+    const gcMock = jest.fn().mockReturnValue(null);
+
+    const resolver = await createResolverWithRealDemo(gatewayMock, gcMock);
+    const req = {
+      method: 'POST',
+      path: '/api/v1/notify',
+      headers: { 'x-consumer-custom-id': 'would-match-if-enabled' },
+    } as never;
+
+    expect(resolver.resolveOptional(req)?.authSource).toBe(
+      'gateway-service-client',
+    );
+    expect(gatewayMock).toHaveBeenCalled();
+  });
+
+  it('inject middleware does not set adapter when auth disabled but other DEMO_* vars are set', () => {
+    process.env = { ...envSnapshot };
+    delete process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED;
+    process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID = 'client-x';
+    process.env.DEMO_NOTIFY_EMAIL_ADAPTER = 'nodemailer';
+
+    const mw = new DemoInjectDeliveryHeadersMiddleware();
+    const next = jest.fn();
+    const r = {
+      method: 'POST',
+      path: '/api/v1/notify',
+      headers: { 'x-consumer-custom-id': 'client-x' },
+    } as Request;
+    mw.use(r, {} as Response, next);
+
+    expect(r.headers['x-delivery-email-adapter']).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/backend/test/demo-notify-gateway/demo-gateway-notify-auth.strategy.spec.ts
+++ b/backend/test/demo-notify-gateway/demo-gateway-notify-auth.strategy.spec.ts
@@ -1,0 +1,92 @@
+import { DemoGatewayNotifyAuthStrategy } from '../../src/demo-notify-gateway/demo-gateway-notify-auth.strategy';
+
+const envSnapshot = { ...process.env };
+
+describe('DemoGatewayNotifyAuthStrategy', () => {
+  let strategy: DemoGatewayNotifyAuthStrategy;
+
+  beforeEach(() => {
+    process.env = { ...envSnapshot };
+    delete process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED;
+    delete process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID;
+    delete process.env.DEMO_NOTIFY_WORKSPACE_ID;
+    delete process.env.DEMO_NOTIFY_AUTH_PATHS;
+    delete process.env.DEMO_NOTIFY_GATEWAY_HEADER;
+    strategy = new DemoGatewayNotifyAuthStrategy();
+  });
+
+  afterAll(() => {
+    process.env = { ...envSnapshot };
+  });
+
+  it('returns null when demo auth is disabled', () => {
+    process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED = 'false';
+    process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID = 'demo-client';
+    expect(
+      strategy.authenticate({
+        method: 'POST',
+        path: '/api/v1/notify',
+        headers: { 'x-consumer-custom-id': 'demo-client' },
+      } as never),
+    ).toBeNull();
+  });
+
+  it('returns null when path does not match', () => {
+    process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED = 'true';
+    process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID = 'demo-client';
+    expect(
+      strategy.authenticate({
+        method: 'GET',
+        path: '/api/v1/notify',
+        headers: { 'x-consumer-custom-id': 'demo-client' },
+      } as never),
+    ).toBeNull();
+  });
+
+  it('returns null when Kong header does not match', () => {
+    process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED = 'true';
+    process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID = 'demo-client';
+    expect(
+      strategy.authenticate({
+        method: 'POST',
+        path: '/api/v1/notify',
+        headers: { 'x-consumer-custom-id': 'other' },
+      } as never),
+    ).toBeNull();
+  });
+
+  it('returns principal when only originalUrl matches configured path', () => {
+    process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED = 'true';
+    process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID = 'demo-client';
+
+    const p = strategy.authenticate({
+      method: 'POST',
+      path: '/notify',
+      originalUrl: '/api/v1/notify',
+      headers: { 'x-consumer-custom-id': 'demo-client' },
+    } as never);
+
+    expect(p?.workspaceId).toBe('default');
+  });
+
+  it('returns principal when path and header match', () => {
+    process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED = 'true';
+    process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID = 'demo-client';
+    process.env.DEMO_NOTIFY_WORKSPACE_ID = 'ws-demo';
+
+    const p = strategy.authenticate({
+      method: 'POST',
+      path: '/api/v1/notify',
+      headers: { 'x-consumer-custom-id': 'demo-client' },
+    } as never);
+
+    expect(p).toEqual({
+      type: 'service',
+      subjectId: 'demo-notify-gateway:demo-client',
+      workspaceId: 'ws-demo',
+      workspaceKind: 'local',
+      gatewayClientId: 'demo-client',
+      authSource: 'demo-gateway-notify',
+    });
+  });
+});

--- a/backend/test/demo-notify-gateway/demo-inject-delivery-headers.middleware.spec.ts
+++ b/backend/test/demo-notify-gateway/demo-inject-delivery-headers.middleware.spec.ts
@@ -1,0 +1,86 @@
+import type { Request, Response, NextFunction } from 'express';
+import { DemoInjectDeliveryHeadersMiddleware } from '../../src/demo-notify-gateway/demo-inject-delivery-headers.middleware';
+
+const envSnapshot = { ...process.env };
+
+describe('DemoInjectDeliveryHeadersMiddleware', () => {
+  let middleware: DemoInjectDeliveryHeadersMiddleware;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    process.env = { ...envSnapshot };
+    delete process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED;
+    delete process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID;
+    delete process.env.DEMO_NOTIFY_EMAIL_ADAPTER;
+    delete process.env.DEMO_NOTIFY_GATEWAY_HEADER;
+    middleware = new DemoInjectDeliveryHeadersMiddleware();
+    next = jest.fn();
+  });
+
+  afterAll(() => {
+    process.env = { ...envSnapshot };
+  });
+
+  function req(
+    overrides: Partial<Pick<Request, 'method' | 'path' | 'headers'>>,
+  ): Request {
+    return {
+      method: 'POST',
+      path: '/api/v1/notify',
+      headers: {},
+      ...overrides,
+    } as Request;
+  }
+
+  it('does nothing when demo auth disabled', () => {
+    const r = req({
+      headers: { 'x-consumer-custom-id': 'demo-client' },
+    });
+    middleware.use(r, {} as Response, next);
+    expect(r.headers['x-delivery-email-adapter']).toBeUndefined();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('injects email adapter when Kong client and path match', () => {
+    process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED = 'true';
+    process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID = 'demo-client';
+    process.env.DEMO_NOTIFY_EMAIL_ADAPTER = 'nodemailer';
+
+    const r = req({
+      headers: { 'x-consumer-custom-id': 'demo-client' },
+    });
+    middleware.use(r, {} as Response, next);
+
+    expect(r.headers['x-delivery-email-adapter']).toBe('nodemailer');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('does not override existing X-Delivery-Email-Adapter', () => {
+    process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED = 'true';
+    process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID = 'demo-client';
+    process.env.DEMO_NOTIFY_EMAIL_ADAPTER = 'nodemailer';
+
+    const r = req({
+      headers: {
+        'x-consumer-custom-id': 'demo-client',
+        'x-delivery-email-adapter': 'ches',
+      },
+    });
+    middleware.use(r, {} as Response, next);
+
+    expect(r.headers['x-delivery-email-adapter']).toBe('ches');
+  });
+
+  it('skips when Kong id mismatch', () => {
+    process.env.DEMO_NOTIFY_GATEWAY_AUTH_ENABLED = 'true';
+    process.env.DEMO_NOTIFY_GATEWAY_CLIENT_ID = 'demo-client';
+    process.env.DEMO_NOTIFY_EMAIL_ADAPTER = 'nodemailer';
+
+    const r = req({
+      headers: { 'x-consumer-custom-id': 'other' },
+    });
+    middleware.use(r, {} as Response, next);
+
+    expect(r.headers['x-delivery-email-adapter']).toBeUndefined();
+  });
+});

--- a/backend/test/notify/notify.service.spec.ts
+++ b/backend/test/notify/notify.service.spec.ts
@@ -66,6 +66,7 @@ describe('NotifyService', () => {
       if (key === 'defaults.email.from') return fallback ?? 'noreply@localhost';
       if (key === 'defaults.templates.defaultSubject')
         return fallback ?? 'Notification';
+      if (key === 'notify.inlineEmailEnabled') return false;
       return undefined;
     });
 
@@ -287,6 +288,151 @@ describe('NotifyService', () => {
         notifyType: 'single-email',
         override: {
           common: { to: ['u@x.com'], templateId: 't-email', sendAs: 'email' },
+        },
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('send inline email when NOTIFY_INLINE_EMAIL_ENABLED without notifyType', async () => {
+    const sendMock = jest.fn().mockResolvedValue({ messageId: 'msg-inline' });
+    const emailTransport: IEmailTransport = {
+      send: sendMock,
+    };
+    const configGetMock = jest.fn((key: string, fallback?: string) => {
+      if (key === 'nodemailer.from') return fallback ?? 'noreply@localhost';
+      if (key === 'defaults.email.from') return fallback ?? 'noreply@localhost';
+      if (key === 'defaults.templates.defaultSubject')
+        return fallback ?? 'Notification';
+      if (key === 'notify.inlineEmailEnabled') return true;
+      return undefined;
+    });
+    const deliveryAdapterResolver = { getEmailAdapter: () => emailTransport };
+    const mod = await Test.createTestingModule({
+      providers: [
+        NotifyService,
+        IdentitiesService,
+        NotifyTypesService,
+        DefaultsService,
+        InMemoryTemplateStore,
+        InMemoryTemplateResolver,
+        InMemoryDefaultsStore,
+        InMemoryNotifyTypeStore,
+        {
+          provide: DEFAULTS_STORE,
+          useExisting: InMemoryDefaultsStore,
+        },
+        { provide: ConfigService, useValue: { get: configGetMock } },
+        { provide: DeliveryAdapterResolver, useValue: deliveryAdapterResolver },
+        {
+          provide: DeliveryContextService,
+          useValue: {
+            getEmailAdapterKey: () => 'nodemailer',
+            getWorkspaceId: () => 'default',
+          },
+        },
+        { provide: TEMPLATE_RESOLVER, useClass: InMemoryTemplateResolver },
+        { provide: TEMPLATE_RENDERER_REGISTRY, useValue: rendererRegistry },
+        { provide: DEFAULT_TEMPLATE_ENGINE, useValue: 'jinja2' },
+        { provide: SENDER_STORE, useClass: InMemorySenderStore },
+      ],
+    }).compile();
+    const inlineSvc = mod.get(NotifyService);
+
+    const result = await inlineSvc.send({
+      override: {
+        common: {
+          to: ['inline@example.com'],
+          subject: 'Hi {{name}}',
+          body: 'Hello {{name}}',
+          renderer: 'jinja2',
+          params: { name: 'Sam' },
+          sendAs: 'email',
+        },
+      },
+    });
+
+    expect(result.notifyId).toBeDefined();
+    expect(sendMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'inline@example.com',
+        subject: 'Hi Sam',
+        body: 'Hello Sam',
+      }),
+    );
+  });
+
+  it('send inline email throws BadRequestException for unknown renderer', async () => {
+    const emailTransport: IEmailTransport = {
+      send: jest.fn().mockResolvedValue({ messageId: 'x' }),
+    };
+    const configGetMock = jest.fn((key: string, fallback?: string) => {
+      if (key === 'nodemailer.from') return fallback ?? 'noreply@localhost';
+      if (key === 'defaults.email.from') return fallback ?? 'noreply@localhost';
+      if (key === 'defaults.templates.defaultSubject')
+        return fallback ?? 'Notification';
+      if (key === 'notify.inlineEmailEnabled') return true;
+      return undefined;
+    });
+    const mod = await Test.createTestingModule({
+      providers: [
+        NotifyService,
+        IdentitiesService,
+        NotifyTypesService,
+        DefaultsService,
+        InMemoryTemplateStore,
+        InMemoryTemplateResolver,
+        InMemoryDefaultsStore,
+        InMemoryNotifyTypeStore,
+        {
+          provide: DEFAULTS_STORE,
+          useExisting: InMemoryDefaultsStore,
+        },
+        { provide: ConfigService, useValue: { get: configGetMock } },
+        {
+          provide: DeliveryAdapterResolver,
+          useValue: { getEmailAdapter: () => emailTransport },
+        },
+        {
+          provide: DeliveryContextService,
+          useValue: {
+            getEmailAdapterKey: () => 'nodemailer',
+            getWorkspaceId: () => 'default',
+          },
+        },
+        { provide: TEMPLATE_RESOLVER, useClass: InMemoryTemplateResolver },
+        { provide: TEMPLATE_RENDERER_REGISTRY, useValue: rendererRegistry },
+        { provide: DEFAULT_TEMPLATE_ENGINE, useValue: 'jinja2' },
+        { provide: SENDER_STORE, useClass: InMemorySenderStore },
+      ],
+    }).compile();
+    const inlineSvc = mod.get(NotifyService);
+
+    await expect(
+      inlineSvc.send({
+        override: {
+          common: {
+            to: ['u@x.com'],
+            subject: 'S',
+            body: 'B',
+            renderer: 'nonexistent-engine-xyz',
+            sendAs: 'email',
+          },
+        },
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('send throws BadRequestException when notifyType missing and inline disabled', async () => {
+    await expect(
+      service.send({
+        override: {
+          common: {
+            to: ['u@x.com'],
+            subject: 'S',
+            body: 'B',
+            renderer: 'jinja2',
+            sendAs: 'email',
+          },
         },
       }),
     ).rejects.toThrow(BadRequestException);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Added some 200 responses for "/" and "/api/v1" so API gateway can recognize this as a running service.  Put in some reasonable Rate limiting for these checks (also added some health/live/ready checks).

For demo, we need a way without a database to allow someone to call the api and fire off an email.
Understood that /api/v1/notify endpoints will all change, so any work here is strictly for demo and short term. Needed to allow inline emails,  not rely on tenants and defaults and notification types and templates.

Also had to add in a way for us to read what client-id is allow (we will give to the other team calling us for the demo). The code fits in with being behind a Gateway, but not necessary for the demo.
All code is as isolated as possible and can be removed as soon as demo is over (backend/src/demo-notify-gateway).
This "module" (essentially middleware) requires configuration via env vars (may have to do this manually - consult with devops). This will mimic having a tenant with an api-client and sender address in the system, thus allowing an api call.

Key point here is that demo-notify-gateway is simply a bandaid that we can remove when we have a database and are behind the gateway.

CCP-3320 - need this work to have something usable to demo and work behind the API gateway.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [x] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [x] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Backend API](https://notify-35-backend.apps.silver.devops.gov.bc.ca)
- [API Docs](https://notify-35-backend.apps.silver.devops.gov.bc.ca/api/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/notify/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/notify/actions/workflows/merge.yml)