### PR TITLE
feat(CCP-3985): implement adapter switching for CHES email endpoints

### DIFF
--- a/backend/src/ches/ches.module.ts
+++ b/backend/src/ches/ches.module.ts
@@ -1,11 +1,14 @@
 import { Module } from '@nestjs/common';
+import { DeliveryContextModule } from '../common/delivery-context/delivery-context.module';
 import { ChesController } from './v1/core/ches.controller';
 import { ChesOAuthService } from './ches-oauth.service';
 import { ChesApiClient } from './ches-api.client';
+import { ChesService } from './ches.service';
 
 @Module({
+  imports: [DeliveryContextModule],
   controllers: [ChesController],
-  providers: [ChesOAuthService, ChesApiClient],
-  exports: [ChesApiClient],
+  providers: [ChesOAuthService, ChesApiClient, ChesService],
+  exports: [ChesApiClient, ChesService],
 })
 export class ChesModule {}

--- a/backend/src/ches/ches.service.ts
+++ b/backend/src/ches/ches.service.ts
@@ -1,0 +1,169 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  NotImplementedException,
+} from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import { DeliveryAdapterResolver } from '../common/delivery-context/delivery-adapter.resolver';
+import type { IEmailTransport } from '../adapters/interfaces';
+import { ChesApiClient } from './ches-api.client';
+import type { ChesStatusQuery } from './ches-api.client';
+import { ChesMessageObject } from './v1/core/schemas/ches-message-object';
+import { ChesTransactionResponse } from './v1/core/schemas/ches-transaction-response';
+import { ChesMergeRequest } from './v1/core/schemas/ches-merge-request';
+import { ChesStatusObject } from './v1/core/schemas/ches-status-object';
+
+@Injectable()
+export class ChesService {
+  private readonly logger = new Logger(ChesService.name);
+
+  constructor(
+    private readonly deliveryAdapterResolver: DeliveryAdapterResolver,
+    private readonly chesApiClient: ChesApiClient,
+  ) {}
+
+  /**
+   * Returns the real email adapter if one is configured, or null to indicate
+   * that requests should fall through to the CHES passthrough client.
+   */
+  private resolveEmailAdapter(): IEmailTransport | null {
+    const adapter = this.deliveryAdapterResolver.getEmailAdapter();
+    if (typeof adapter === 'object' && adapter !== null && 'send' in adapter) {
+      return adapter;
+    }
+    return null;
+  }
+
+  async sendEmail(body: ChesMessageObject): Promise<ChesTransactionResponse> {
+    const adapter = this.resolveEmailAdapter();
+
+    if (!adapter) {
+      return this.chesApiClient.sendEmail(body);
+    }
+
+    const txId = uuidv4();
+    const msgId = uuidv4();
+
+    this.logger.log(`Sending email via adapter to ${body.to[0]}: txId=${txId}`);
+
+    await adapter.send({
+      to: body.to[0],
+      subject: body.subject,
+      body: body.body,
+      from: body.from,
+    });
+
+    return {
+      txId,
+      messages: [{ msgId, to: body.to }],
+    };
+  }
+
+  async sendEmailMerge(
+    body: ChesMergeRequest,
+  ): Promise<ChesTransactionResponse[]> {
+    const adapter = this.resolveEmailAdapter();
+
+    if (!adapter) {
+      return this.chesApiClient.sendEmailMerge(body);
+    }
+
+    const results: ChesTransactionResponse[] = [];
+
+    for (const ctx of body.contexts) {
+      const txId = uuidv4();
+      const msgId = uuidv4();
+
+      this.logger.log(
+        `Sending merge email via adapter to ${ctx.to[0]}: txId=${txId}`,
+      );
+
+      await adapter.send({
+        to: ctx.to[0],
+        subject: body.subject,
+        body: body.body,
+        from: body.from,
+      });
+
+      results.push({ txId, messages: [{ msgId, to: ctx.to }] });
+    }
+
+    return results;
+  }
+
+  async previewEmailMerge(
+    body: ChesMergeRequest,
+  ): Promise<ChesMessageObject[]> {
+    const adapter = this.resolveEmailAdapter();
+
+    if (!adapter) {
+      return this.chesApiClient.previewEmailMerge(body);
+    }
+
+    throw new NotImplementedException(
+      'emailMerge preview is not supported when using a non-CHES adapter',
+    );
+  }
+
+  async getStatusQuery(query: ChesStatusQuery): Promise<ChesStatusObject[]> {
+    const adapter = this.resolveEmailAdapter();
+
+    if (!adapter) {
+      return this.chesApiClient.getStatusQuery(query);
+    }
+
+    // Emails sent via a real adapter are fire-and-forget; no queue to query
+    return [];
+  }
+
+  async getStatusMessage(msgId: string): Promise<ChesStatusObject> {
+    const adapter = this.resolveEmailAdapter();
+
+    if (!adapter) {
+      return this.chesApiClient.getStatusMessage(msgId);
+    }
+
+    throw new NotFoundException(`Message ${msgId} not found`);
+  }
+
+  async promoteQuery(query: ChesStatusQuery): Promise<void> {
+    const adapter = this.resolveEmailAdapter();
+
+    if (!adapter) {
+      return this.chesApiClient.promoteQuery(query);
+    }
+
+    // No-op: real adapters send immediately, no queue to promote from
+  }
+
+  async promoteMessage(msgId: string): Promise<void> {
+    const adapter = this.resolveEmailAdapter();
+
+    if (!adapter) {
+      return this.chesApiClient.promoteMessage(msgId);
+    }
+
+    // No-op: real adapters send immediately, no queue to promote from
+  }
+
+  async cancelQuery(query: ChesStatusQuery): Promise<void> {
+    const adapter = this.resolveEmailAdapter();
+
+    if (!adapter) {
+      return this.chesApiClient.cancelQuery(query);
+    }
+
+    // No-op: real adapters send immediately, no queue to cancel from
+  }
+
+  async cancelMessage(msgId: string): Promise<void> {
+    const adapter = this.resolveEmailAdapter();
+
+    if (!adapter) {
+      return this.chesApiClient.cancelMessage(msgId);
+    }
+
+    // No-op: real adapters send immediately, no queue to cancel from
+  }
+}

--- a/backend/src/ches/v1/core/ches.controller.ts
+++ b/backend/src/ches/v1/core/ches.controller.ts
@@ -20,7 +20,7 @@ import {
   ApiBody,
 } from '@nestjs/swagger';
 import { AuthenticatedGuard } from '../../../common/guards';
-import { ChesApiClient } from '../../ches-api.client';
+import { ChesService } from '../../ches.service';
 import type { ChesStatusQuery } from '../../ches-api.client';
 import { ChesMessageObject } from './schemas/ches-message-object';
 import { ChesTransactionResponse } from './schemas/ches-transaction-response';
@@ -32,7 +32,7 @@ import { ChesStatusObject } from './schemas/ches-status-object';
 @UseGuards(AuthenticatedGuard)
 @Controller('ches')
 export class ChesController {
-  constructor(private readonly chesApiClient: ChesApiClient) {}
+  constructor(private readonly chesService: ChesService) {}
 
   @Post('email')
   @HttpCode(HttpStatus.CREATED)
@@ -52,7 +52,7 @@ export class ChesController {
   async postEmail(
     @Body() body: ChesMessageObject,
   ): Promise<ChesTransactionResponse> {
-    return this.chesApiClient.sendEmail(body);
+    return this.chesService.sendEmail(body);
   }
 
   @Post('emailMerge')
@@ -69,7 +69,7 @@ export class ChesController {
   async postMerge(
     @Body() body: ChesMergeRequest,
   ): Promise<ChesTransactionResponse[]> {
-    return this.chesApiClient.sendEmailMerge(body);
+    return this.chesService.sendEmailMerge(body);
   }
 
   @Post('emailMerge/preview')
@@ -85,7 +85,7 @@ export class ChesController {
   async postPreview(
     @Body() body: ChesMergeRequest,
   ): Promise<ChesMessageObject[]> {
-    return this.chesApiClient.previewEmailMerge(body);
+    return this.chesService.previewEmailMerge(body);
   }
 
   @Get('status')
@@ -107,7 +107,7 @@ export class ChesController {
   async getStatusQuery(
     @Query() query: ChesStatusQuery,
   ): Promise<ChesStatusObject[]> {
-    return this.chesApiClient.getStatusQuery(query);
+    return this.chesService.getStatusQuery(query);
   }
 
   @Get('status/:msgId')
@@ -123,7 +123,7 @@ export class ChesController {
   async getStatusMessage(
     @Param('msgId') msgId: string,
   ): Promise<ChesStatusObject> {
-    return this.chesApiClient.getStatusMessage(msgId);
+    return this.chesService.getStatusMessage(msgId);
   }
 
   @Post('promote')
@@ -140,7 +140,7 @@ export class ChesController {
   @ApiResponse({ status: 202, description: 'Messages promoted' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async postPromoteQuery(@Query() query: ChesStatusQuery): Promise<void> {
-    return this.chesApiClient.promoteQuery(query);
+    return this.chesService.promoteQuery(query);
   }
 
   @Post('promote/:msgId')
@@ -151,7 +151,7 @@ export class ChesController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Message not found' })
   async postPromoteMessage(@Param('msgId') msgId: string): Promise<void> {
-    return this.chesApiClient.promoteMessage(msgId);
+    return this.chesService.promoteMessage(msgId);
   }
 
   @Delete('cancel')
@@ -168,7 +168,7 @@ export class ChesController {
   @ApiResponse({ status: 202, description: 'Messages cancelled' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async deleteCancelQuery(@Query() query: ChesStatusQuery): Promise<void> {
-    return this.chesApiClient.cancelQuery(query);
+    return this.chesService.cancelQuery(query);
   }
 
   @Delete('cancel/:msgId')
@@ -179,7 +179,7 @@ export class ChesController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Message not found' })
   async deleteCancelMessage(@Param('msgId') msgId: string): Promise<void> {
-    return this.chesApiClient.cancelMessage(msgId);
+    return this.chesService.cancelMessage(msgId);
   }
 
   @Get('health')

--- a/backend/test/ches/v1/core/ches.controller.spec.ts
+++ b/backend/test/ches/v1/core/ches.controller.spec.ts
@@ -1,29 +1,29 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotImplementedException } from '@nestjs/common';
 import { ChesController } from '../../../../src/ches/v1/core/ches.controller';
-import { ChesApiClient } from '../../../../src/ches/ches-api.client';
+import { ChesService } from '../../../../src/ches/ches.service';
 
 describe('ChesController', () => {
   let controller: ChesController;
-  const notImplemented = new NotImplementedException();
+
+  const mockChesService = {
+    sendEmail: jest.fn().mockResolvedValue({ txId: 'tx-1', messages: [] }),
+    sendEmailMerge: jest.fn().mockResolvedValue([]),
+    previewEmailMerge: jest.fn().mockResolvedValue([]),
+    getStatusQuery: jest.fn().mockResolvedValue([]),
+    getStatusMessage: jest.fn().mockResolvedValue({}),
+    promoteQuery: jest.fn().mockResolvedValue(undefined),
+    promoteMessage: jest.fn().mockResolvedValue(undefined),
+    cancelQuery: jest.fn().mockResolvedValue(undefined),
+    cancelMessage: jest.fn().mockResolvedValue(undefined),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ChesController],
       providers: [
         {
-          provide: ChesApiClient,
-          useValue: {
-            sendEmail: jest.fn().mockRejectedValue(notImplemented),
-            sendEmailMerge: jest.fn().mockRejectedValue(notImplemented),
-            previewEmailMerge: jest.fn().mockRejectedValue(notImplemented),
-            getStatusQuery: jest.fn().mockRejectedValue(notImplemented),
-            getStatusMessage: jest.fn().mockRejectedValue(notImplemented),
-            promoteQuery: jest.fn().mockRejectedValue(notImplemented),
-            promoteMessage: jest.fn().mockRejectedValue(notImplemented),
-            cancelQuery: jest.fn().mockRejectedValue(notImplemented),
-            cancelMessage: jest.fn().mockRejectedValue(notImplemented),
-          },
+          provide: ChesService,
+          useValue: mockChesService,
         },
       ],
     }).compile();
@@ -31,58 +31,61 @@ describe('ChesController', () => {
     controller = module.get(ChesController);
   });
 
-  it('postEmail throws NotImplementedException', async () => {
-    await expect(controller.postEmail({} as never)).rejects.toThrow(
-      NotImplementedException,
-    );
+  it('postEmail delegates to ChesService', async () => {
+    const body = {
+      from: 'a@b.com',
+      to: ['c@d.com'],
+      subject: 'Test',
+      body: 'Hello',
+      bodyType: 'html',
+    } as never;
+    const result = await controller.postEmail(body);
+    expect(mockChesService.sendEmail).toHaveBeenCalledWith(body);
+    expect(result).toEqual({ txId: 'tx-1', messages: [] });
   });
 
-  it('postMerge throws NotImplementedException', async () => {
-    await expect(controller.postMerge({} as never)).rejects.toThrow(
-      NotImplementedException,
-    );
+  it('postMerge delegates to ChesService', async () => {
+    const result = await controller.postMerge({} as never);
+    expect(mockChesService.sendEmailMerge).toHaveBeenCalled();
+    expect(result).toEqual([]);
   });
 
-  it('postPreview throws NotImplementedException', async () => {
-    await expect(controller.postPreview({} as never)).rejects.toThrow(
-      NotImplementedException,
-    );
+  it('postPreview delegates to ChesService', async () => {
+    const result = await controller.postPreview({} as never);
+    expect(mockChesService.previewEmailMerge).toHaveBeenCalled();
+    expect(result).toEqual([]);
   });
 
-  it('getStatusQuery throws NotImplementedException', async () => {
-    await expect(controller.getStatusQuery({})).rejects.toThrow(
-      NotImplementedException,
-    );
+  it('getStatusQuery delegates to ChesService', async () => {
+    const result = await controller.getStatusQuery({});
+    expect(mockChesService.getStatusQuery).toHaveBeenCalled();
+    expect(result).toEqual([]);
   });
 
-  it('getStatusMessage throws NotImplementedException', async () => {
-    await expect(controller.getStatusMessage('msg-1')).rejects.toThrow(
-      NotImplementedException,
-    );
+  it('getStatusMessage delegates to ChesService', async () => {
+    const result = await controller.getStatusMessage('msg-1');
+    expect(mockChesService.getStatusMessage).toHaveBeenCalledWith('msg-1');
+    expect(result).toEqual({});
   });
 
-  it('postPromoteQuery throws NotImplementedException', async () => {
-    await expect(controller.postPromoteQuery({})).rejects.toThrow(
-      NotImplementedException,
-    );
+  it('postPromoteQuery delegates to ChesService', async () => {
+    await controller.postPromoteQuery({});
+    expect(mockChesService.promoteQuery).toHaveBeenCalled();
   });
 
-  it('postPromoteMessage throws NotImplementedException', async () => {
-    await expect(controller.postPromoteMessage('msg-1')).rejects.toThrow(
-      NotImplementedException,
-    );
+  it('postPromoteMessage delegates to ChesService', async () => {
+    await controller.postPromoteMessage('msg-1');
+    expect(mockChesService.promoteMessage).toHaveBeenCalledWith('msg-1');
   });
 
-  it('deleteCancelQuery throws NotImplementedException', async () => {
-    await expect(controller.deleteCancelQuery({})).rejects.toThrow(
-      NotImplementedException,
-    );
+  it('deleteCancelQuery delegates to ChesService', async () => {
+    await controller.deleteCancelQuery({});
+    expect(mockChesService.cancelQuery).toHaveBeenCalled();
   });
 
-  it('deleteCancelMessage throws NotImplementedException', async () => {
-    await expect(controller.deleteCancelMessage('msg-1')).rejects.toThrow(
-      NotImplementedException,
-    );
+  it('deleteCancelMessage delegates to ChesService', async () => {
+    await controller.deleteCancelMessage('msg-1');
+    expect(mockChesService.cancelMessage).toHaveBeenCalledWith('msg-1');
   });
 
   it('getHealth returns dependencies array', () => {


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

# Description

## What this PR does

Adds a ChesService layer that implements the same adapter switching 
pattern as GcNotifyService for all CHES endpoints.

Previously POST /ches/email was hardwired directly to ChesApiClient.
Now all CHES endpoints route through ChesService which selects the 
correct delivery adapter based on configuration or request header.

## Adapter behaviour

- No header (default) → ches:passthrough → ChesApiClient → real CHES API
- X-Delivery-Email-Adapter: ches:passthrough → ChesApiClient
- X-Delivery-Email-Adapter: ches → ChesEmailTransport
- X-Delivery-Email-Adapter: nodemailer → NodemailerTransport

## Files changed

- `ches.service.ts` — new service with adapter switching for all endpoints
- `ches.module.ts` — imports DeliveryContextModule, registers ChesService
- `ches.controller.ts` — now delegates all endpoints to ChesService

## Testing

- ches:passthrough → real email delivered via CHES 
- nodemailer → routed via nodemailer adapter 

## Notes

- emailMerge preview throws NotImplementedException for non-CHES adapters
- status/promote/cancel return empty/no-op for non-CHES adapters 
  (fire-and-forget, no queue to query)

Closes CCP-3985
Linked to CCP-3828

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

<!-- Please describe the tests you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- Please delete options that are not relevant. -->

- [ ] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [ ] Updated existing tests


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
